### PR TITLE
Update pci.h

### DIFF
--- a/hypervisor/include/jailhouse/pci.h
+++ b/hypervisor/include/jailhouse/pci.h
@@ -52,7 +52,7 @@
 #define PCI_BDF_PARAMS(bdf)	(bdf) >> 8, ((bdf) >> 3) & 0x1f, (bdf) & 7
 
 /** Static limit of MSI-X vectors supported by Jailhouse per device. */
-#define PCI_MAX_MSIX_VECTORS	16
+#define PCI_MAX_MSIX_VECTORS	2048
 
 /**
  * Access moderation return codes.


### PR DESCRIPTION
The MSIX VECTOR should be up to 2048.

In my board, there is a device which its MSIX vector is 80. when we active the hypervisor ,it will fail. so we need modify the marco to 2048.