### PR TITLE
running/locked in sysfs-entries.txt and a typo in entry.h

### DIFF
--- a/Documentation/sysfs-entries.txt
+++ b/Documentation/sysfs-entries.txt
@@ -13,7 +13,7 @@ can be used for monitoring the state of the hypervisor and its cells.
 `- cells
    |- <name of cell>
    |  |- id                     - unique numerical ID
-   |  |- state                  - "running", "shut down", or "failed"
+   |  |- state                  - "running", "running/locked", "shut down", or "failed"
    |  |- cpus_assigned          - bitmask of assigned logical CPUs
    |  |- cpus_failed            - bitmask of logical CPUs that caused a failure
    |  `- statistics

--- a/hypervisor/include/jailhouse/entry.h
+++ b/hypervisor/include/jailhouse/entry.h
@@ -51,7 +51,7 @@ extern struct jailhouse_header hypervisor_header;
  *
  * The functions always returns the same value on each CPU it is invoked on.
  *
- * @note This function has to be called for every configures CPU or the setup
+ * @note This function has to be called for every configured CPU or the setup
  * will fail.
  *
  * @see entry
@@ -69,7 +69,7 @@ int arch_entry(unsigned int cpu_id);
  * The functions is called by arch_entry(). It always returns the same value on
  * each CPU it is invoked on.
  *
- * @note This function has to be called for every configures CPU or the setup
+ * @note This function has to be called for every configured CPU or the setup
  * will fail.
  *
  * @see arch_entry


### PR DESCRIPTION
Cell state 'running/locked' documented as suggested by Henning Schild on the mailing list and a typo fix.

Signed-off-by: Christian Loehle <cloehle@linutronix.de>