### PR TITLE
documentation modify.

### DIFF
--- a/Documentation/articles/LJ-article-04-2015.txt
+++ b/Documentation/articles/LJ-article-04-2015.txt
@@ -291,7 +291,7 @@ sudo tools/jailhouse cell list
 
 For more detailed statistics, run:
 
-sudo tools/jailhouse cell stat apic-demo
+sudo tools/jailhouse cell stats apic-demo
 
 The data you see is updated periodically (as in top utility) and contains
 various low-level counters like the number of hypercalls issued, or the


### PR DESCRIPTION
In the article of LJ-article-04-2015, section of jailhouse for real, the
cell state cmd should be "sudo tools/jailhouse cell stats apic-demo",
but actually it is "sudo tools/jailhouse cell stat apic-demo", so
modified.