### PR TITLE
README: add note about not using the serial port in the guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ need to add
 
     memmap=66M$0x3b000000
 
-as parameter to the command line of the virtual machine's kernel. Reboot the
-guest and load jailhouse.ko. Then enable Jailhouse like this:
+as parameter to the command line of the virtual machine's kernel. The Jailhouse
+QEMU cell config will block use of the serial port by the guest OS, so make
+sure that the guest kernel command line does NOT have its console set to log
+to the serial port (ie remove any 'console=ttyS0' arguments from the grub
+config). Reboot the guest and load jailhouse.ko. Then enable Jailhouse like
+this:
 
     jailhouse enable /path/to/qemu-vm.cell
 


### PR DESCRIPTION
The Jailhouse qemu-vm.celll config will prevent the root cell
accessing the serial port, so add a note about not using this
for the guest OS console.