### PR TITLE
allow used of CC from build environnement

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,7 +10,7 @@
 # the COPYING file in the top-level directory.
 #
 
-CC = $(CROSS_COMPILE)gcc
+CC ?= $(CROSS_COMPILE)gcc
 
 CFLAGS = -g -O3 -I../driver -DLIBEXECDIR=\"$(libexecdir)\" \
 	-Wall -Wextra -Wmissing-declarations -Wmissing-prototypes -Werror \


### PR DESCRIPTION
 * If you use a cross build system (yocto,...)
   you may want to use CC value from build environnement.

Signed-off-by: Ronan <ronan.lemartret@iot.bzh>