### PR TITLE
Adding the sram region to HiKey config file.

### DIFF
--- a/Documentation/setup-on-emtrion-emcon-rz-boards.md
+++ b/Documentation/setup-on-emtrion-emcon-rz-boards.md
@@ -1,0 +1,97 @@
+Setup on emtrion's emCON-RZ/G1x series board
+============================================
+
+The emCON-RZ/G1x boards from emtrion are boards with SoCs from the Renesas RZ/G series:
+
+- emCON-RZ/G1E has a RZ/G1E processor (dual-core Cortex-A7)
+- emCON-RZ/G1M has a RZ/G1M processor (dual-core Cortex-A15)
+- emCON-RZ/G1H has a RZ/G1H processor (quad-core Cortex-A15/Cortex-A7)
+
+These boards run mainline Linux kernels and U-Boot with patches from Renesas and emtrion.
+Further information can be found on https://www.emtrion.de and https://support.emtrion.de.
+
+In order to run Jailhouse, the Linux kernel version should be at least 4.4.49 and U-Boot
+should be at least 2016.07. The Linux configuration used for continuous integration
+builds can serve as reference, see `ci/kernel-config-emtrion-emcon-rzg`.
+
+Adjusting kernel boot parameters via U-Boot
+-------------------------------------------
+Jailhouse needs the Linux kernel boot parameters mem= and vmalloc= to be set in order to reserve memory for other cells.
+In our case we chose mem=750M and vmalloc=384M.
+
+To set these values, you have to change the Linux kernel boot parameters via U-Boot accordingly.
+
+Install and start Jailhouse on emCON-RZ/G1x
+-------------------------------------------
+First we need access to the RootFS of the Linux running on the emCON-RZ/G1x. We assume that you
+have mounted this on your development workstation through sshfs or nfs.
+
+Copy the Jailhouse config file to the hypervisor include directory:
+
+cp -av ci/jailhouse-config-emcon-rzg.h hypervisor/include/jailhouse/config.h
+
+Then you can compile and install Jailhouse using this command on the development workstation:
+
+make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- KERNELRELEASE=<kernel version>-emconrzg1x KDIR=<path to linux kernel source code> DESTDIR=<path to the root of the rootfs> install
+
+**In the following replace the x with the last letter of the specific board name.**
+
+Jailhouse is now installed on the emCON-RZ/G1x board. But we also need the configuration
+of the root cell. We have to copy this configuration manually using these commands on the
+command line on the development workstation:
+
+mkdir -p /jailhouse/configs
+cp configs/emtrion-rzg1**x**.cell /jailhouse/configs
+
+Now we can unmount the RootFS of the emCON-RZ/G1x board because the other steps are executed
+on the emCON-RZ/G1x board. On the console of the started Linux on emCON-RZ/G1x execute the
+following commands to enable Jailhouse:
+
+modprobe jailhouse
+jailhouse enable /jailhouse/configs/emtrion-rzg1**x**.cell
+
+Running the Jailhouse UART demo as an inmate on emcon-RZ/G1x
+------------------------------------------------------------
+The Jailhouse project contains a bare-metal inmate sample called uart-demo. This demo outputs
+a string on the serial device in a loop.
+
+First you have to copy the following files from the Jailhouse development tree into the RootFS
+of the root cell:
+
+cp configs/emtrion-rzg1**x**-uart-demo.cell /jailhouse/configs
+mkdir -p /jailhouse/inmates/uart-demo
+cp inmates/demos/arm/uart-demo.bin /jailhouse/inmates
+
+We assume that the config file is available in the path /jailhouse/configs and the binary file
+is available in the path /jailhouse/inmates/uart-demo. Then you can start the sample using
+the following commands:
+
+jailhouse cell create /jailhouse/configs/emtrion-rzg1**x**-uart-demo.cell
+jailhouse cell load emtrion-emconrzg1**x**-uart-demo /jailhouse/inmates/uart-demo/uart-demo.bin
+jailhouse cell start emtrion-emconrzg1**x**-uart-demo
+
+The uart-demo will be started as an inmate and outputs strings through the serial port SCIF4.
+
+Running Linux as an inmate on emCON-RZ/G1x
+------------------------------------------
+The sample Linux inmate is setup to use the following devices:
+
+- SCIF4 as serial console
+- SDC0 where the RootFS should be stored
+- I2C2
+
+First you have to copy the following files from the Jailhouse tree into the RootFS of the
+root cell:
+
+cp configs/emtrion-rzg1**x**-linux-demo.cell /jailhouse/configs
+cp configs/dts/inmate-emtrion-emconrzg1**x**.dtb /jailhouse/configs
+
+We assume that these files are available in the path /jailhouse/configs on the RootFS of the
+root cell. Make sure you have installed Python on the emCON-RZ/G1x board.
+
+Then we can start the linux inmate executing the following command line in the root cell:
+
+jailhouse cell linux /jailhouse/configs/emtrion-rzg1**x**-linux-demo.cell /boot/zImage -d /jailhouse/configs/inmate-emtrion-emconrzg1**x**.dtb -c "console=ttySC4,115200 cma=16M vmalloc=80M rootwait root=/dev/mmcblk0p2 vt.global_cursor_default=0 consoleblank=0"
+
+The Linux kernel in the inmate will be started. This Linux kernel uses the devices mentioned above and
+searches on the second partition of the SD card for its RootFS.

--- a/configs/dts/inmate-emtrion-emconrzg1e.dts
+++ b/configs/dts/inmate-emtrion-emconrzg1e.dts
@@ -1,0 +1,446 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Device tree for Linux inmate test on emCON-RZ/G1E board,
+ * corresponds to configs/emtrion-emconrzg1e-linux-demo.c
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Ruediger Fichter <ruediger.fichter@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/clock/r8a7745-clock.h>
+#include <dt-bindings/power/r8a7745-sysc.h>
+
+/dts-v1/;
+
+/memreserve/ 0x0000000070000000 0x0000000000002000;
+/ {
+	model = "Jailhouse cell on emCON-RZ/G1E";
+	compatible = "emtrion,emconrzg1e", "renesas,r8a7745";
+
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	interrupt-parent = <&gic>;
+
+	aliases {
+		i2c2 = "/i2c@e6530000";
+		serial4 = "/serial@e6ee0000";
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			enable-method = "psci";
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			reg = <0x0>;
+			clock-frequency = <0x3b9aca00>;
+			power-domains = <0x2 0x5>;
+			clocks = <0x3>;
+			operating-points = <0xf4240 0xf4240>;
+			next-level-cache = <0x4>;
+			linux,phandle = <0x5>;
+			phandle = <0x5>;
+		};
+	};
+
+	memory@70000000 {
+		device_type = "memory";
+		reg = <0x0 0x70000000 0x0 0x0bef0000>;
+	};
+
+	chosen {
+		bootargs = "console=ttySC4,115200 root=/dev/sda1 rootwait
+			    ip=dhcp loglevel=8 vt.global_cursor_default=0
+			    consoleblank=0";
+		stdout-path = "/serial@e6ee0000";
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupts = <GIC_PPI 13
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 14
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 11
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 10
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>;
+	};
+
+	clocks {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		/* External root clock */
+		extal_clk: extal_clk {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <20000000>;
+			clock-output-names = "extal";
+		};
+
+		/*
+		 * The external audio clocks are configured as 0 Hz fixed
+		 * frequency clocks by default. Boards that provide audio
+		 * clocks should override them.
+		 */
+		audio_clka: audio_clka {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			clock-output-names = "audio_clka";
+		};
+		audio_clkb: audio_clkb {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			clock-output-names = "audio_clkb";
+		};
+		audio_clkc: audio_clkc {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <0>;
+			clock-output-names = "audio_clkc";
+		};
+
+		/* Special CPG clocks */
+		cpg_clocks: cpg_clocks@e6150000 {
+			compatible = "renesas,r8a7745-cpg-clocks",
+				     "renesas,rcar-gen2-cpg-clocks";
+			reg = <0 0xe6150000 0 0x1000>;
+			clocks = <&extal_clk>;
+			#clock-cells = <1>;
+			clock-output-names = "main", "pll0", "pll1", "pll3",
+					     "lb", "qspi", "sdh", "sd0";
+			#power-domain-cells = <0>;
+		};
+
+		/* Variable factor clocks */
+		sd2_clk: sd2_clk@e6150078 {
+			compatible = "renesas,r8a7745-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0 0xe6150078 0 4>;
+			clocks = <&pll1_div2_clk>;
+			#clock-cells = <0>;
+			clock-output-names = "sd2";
+		};
+		sd3_clk: sd3_clk@e615026c {
+			compatible = "renesas,r8a7745-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0 0xe615026c 0 4>;
+			clocks = <&pll1_div2_clk>;
+			#clock-cells = <0>;
+			clock-output-names = "sd3";
+		};
+		mmc0_clk: mmc0_clk@e6150240 {
+			compatible = "renesas,r8a7745-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0 0xe6150240 0 4>;
+			clocks = <&pll1_div2_clk>;
+			#clock-cells = <0>;
+			clock-output-names = "mmc0";
+		};
+
+		/* Fixed factor clocks */
+		pll1_div2_clk: pll1_div2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "pll1_div2";
+		};
+
+		z2: z2 {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL0>;
+			#clock-cells = <0>;
+			clock-div = <3>;
+			clock-mult = <1>;
+			clock-output-names = "z2";
+		};
+
+		zg_clk: zg_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <6>;
+			clock-mult = <1>;
+			clock-output-names = "zg";
+		};
+
+		zx_clk: zx_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <3>;
+			clock-mult = <1>;
+			clock-output-names = "zx";
+		};
+
+		zs_clk: zs_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <6>;
+			clock-mult = <1>;
+			clock-output-names = "zs";
+		};
+
+		/* Fixed factor clocks */
+		hp_clk: hp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <12>;
+			clock-mult = <1>;
+			clock-output-names = "hp";
+		};
+		i_clk: i_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "i";
+		};
+		b_clk: b_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <12>;
+			clock-mult = <1>;
+			clock-output-names = "b";
+		};
+		p_clk: p_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <24>;
+			clock-mult = <1>;
+			clock-output-names = "p";
+		};
+		cl_clk: cl_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <48>;
+			clock-mult = <1>;
+			clock-output-names = "cl";
+		};
+		m2_clk: m2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "m2";
+		};
+		imp_clk: imp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <4>;
+			clock-mult = <1>;
+			clock-output-names = "imp";
+		};
+		rclk_clk: rclk_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <(48 * 1024)>;
+			clock-mult = <1>;
+			clock-output-names = "rclk";
+		};
+		oscclk_clk: oscclk_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <(12 * 1024)>;
+			clock-mult = <1>;
+			clock-output-names = "oscclk";
+		};
+		zb3_clk: zb3_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL3>;
+			#clock-cells = <0>;
+			clock-div = <4>;
+			clock-mult = <1>;
+			clock-output-names = "zb3";
+		};
+		zb3d2_clk: zb3d2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL3>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "zb3d2";
+		};
+		ddr_clk: ddr_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL3>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "ddr";
+		};
+		mp_clk: mp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&pll1_div2_clk>;
+			#clock-cells = <0>;
+			clock-div = <15>;
+			clock-mult = <1>;
+			clock-output-names = "mp";
+		};
+		cp_clk: cp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7745_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <48>;
+			clock-mult = <1>;
+			clock-output-names = "cp";
+		};
+		acp_clk: acp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&extal_clk>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "acp";
+		};
+
+		/* Gate clocks */
+		mstp3_clks: mstp3_clks@e615013c {
+			compatible = "renesas,r8a7745-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe615013c 0 4>, <0 0xe6150048 0 4>;
+			clocks = <&cpg_clocks R8A7745_CLK_SD0>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7745_CLK_SDHI0>;
+			clock-output-names = "sdhi0";
+		};
+
+		mstp7_clks: mstp7_clks@e615014c {
+			compatible = "renesas,r8a7745-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe615014c 0 4>, <0 0xe61501c4 0 4>;
+			clocks = <&p_clk>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7745_CLK_SCIF4>;
+			clock-output-names = "scif4";
+		};
+
+		mstp9_clks: mstp9_clks@e6150994 {
+			compatible = "renesas,r8a7745-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe6150994 0 4>, <0 0xe61509a4 0 4>;
+			clocks = <&hp_clk>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7745_CLK_I2C2>;
+			clock-output-names = "i2c2";
+		};
+	};
+
+	vcc_sdhi0: regulator@0 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "SDHI0 Vcc";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		regulator-boot-on;
+		regulator-always-on;
+
+	};
+
+	vccq_sdhi0: regulator@1 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "SDHI0 VccQ";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gic: interrupt-controller@f1001000 {
+		compatible = "arm,cortex-a7-gic", "arm,cortex-a15-gic";
+		reg = <0x0 0xf1001000 0x0 0x1000>,
+		      <0x0 0xf1002000 0x0 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
+	sysc: system-controller@e6180000 {
+		compatible = "renesas,r8a7745-sysc";
+		reg = <0 0xe6180000 0 0x0200>;
+		#power-domain-cells = <1>;
+	};
+
+	pfc: pin-controller@e6060000 {
+		compatible = "renesas,pfc-r8a7745";
+		reg = <0x0 0xe6060000 0x0 0x11c>;
+		#gpio-range-cells = <0x3>;
+		linux,phandle = <0x7>;
+		phandle = <0x7>;
+
+		serial4 {
+			renesas,groups = "scif4_data_c";
+			renesas,function = "scif4";
+			linux,phandle = <0x12>;
+			phandle = <0x12>;
+		};
+
+		sdhi0_pins: sd0 {
+			renesas,groups = "sdhi0_data4", "sdhi0_ctrl",
+					 "sdhi0_cd", "sdhi0_wp";
+			renesas,function = "sdhi0";
+		};
+	};
+
+	scif4: serial@e6ee0000 {
+		compatible = "renesas,scif-r8a7745", "renesas,scif";
+		reg = <0 0xe6ee0000 0 0x40>;
+		interrupts = <0 24 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp7_clks R8A7745_CLK_SCIF4>;
+		clock-names = "sci_ick";
+		power-domains = <&sysc R8A7745_PD_ALWAYS_ON>;
+		status = "okay";
+		pinctrl-0 = <0x12>;
+		pinctrl-names = "default";
+	};
+
+	sdhi0: sd@ee100000 {
+		compatible = "renesas,sdhi-r8a7745";
+		reg = <0 0xee100000 0 0x200>;
+		interrupts = <0 165 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp3_clks R8A7745_CLK_SDHI0>;
+		power-domains = <&sysc R8A7745_PD_ALWAYS_ON>;
+		status = "okay";
+		vmmc-supply = <&vcc_sdhi0>;
+		vqmmc-supply = <&vccq_sdhi0>;
+	};
+
+	i2c2: i2c@e6530000 {
+		compatible = "renesas,i2c-r8a7745";
+		reg = <0 0xe6530000 0 0x40>;
+		interrupts = <0 286 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp9_clks R8A7745_CLK_I2C2>;
+		power-domains = <&sysc R8A7745_PD_ALWAYS_ON>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "okay";
+	};
+};

--- a/configs/dts/inmate-emtrion-emconrzg1m.dts
+++ b/configs/dts/inmate-emtrion-emconrzg1m.dts
@@ -1,0 +1,442 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Device tree for Linux inmate test on emCON-RZ/G1M board,
+ * corresponds to configs/emtrion-emconrzg1m-linux-demo.c
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Jan von Wiarda <jan.vonwiarda@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/clock/r8a7743-clock.h>
+#include <dt-bindings/power/r8a7743-sysc.h>
+
+/dts-v1/;
+
+/memreserve/ 0x0000000070000000 0x0000000000002000;
+/ {
+	model = "Jailhouse cell on emCON-RZ/G1M";
+	compatible = "emtrion,emconrzg1m", "renesas,r8a7743";
+
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	interrupt-parent = <&gic>;
+
+	aliases {
+		i2c2 = "/i2c@e6530000";
+		serial6 = "/serial@e6ee0000";
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			enable-method = "psci";
+			device_type = "cpu";
+			compatible = "arm,cortex-a15";
+			reg = <0x0>;
+			clock-frequency = <0x59682f00>;
+			voltage-tolerance = <0x1>;
+			clocks = <0x2 0x8>;
+			clock-latency = <0x493e0>;
+			power-domains = <0x3 0x0>;
+			operating-points = <0x16e360 0xf4240 0x1406f4 0xf4240
+					    0x112a88 0xf4240 0xe4e1c 0xf4240
+					    0xb71b0 0xf4240 0x5b8d8 0xf4240>;
+		};
+	};
+
+	memory@70000000 {
+		device_type = "memory";
+		reg = <0x0 0x70000000 0x0 0x0bef0000>;
+	};
+
+	chosen {
+		bootargs = "console=ttySC6,115200 root=/dev/sda1 rootwait
+			    ip=dhcp loglevel=8 vt.global_cursor_default=0
+			    consoleblank=0";
+		stdout-path = "/serial@e6ee0000";
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupts = <GIC_PPI 13
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 14
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 11
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
+			     <GIC_PPI 10
+				(GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>;
+	};
+
+	clocks {
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+
+		/* External root clock */
+		extal_clk: extal_clk {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <20000000>;
+			clock-output-names = "extal";
+		};
+
+		audio_clka {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			clock-frequency = <0x0>;
+			clock-output-names = "audio_clka";
+		};
+		audio_clkb {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			clock-frequency = <0x0>;
+			clock-output-names = "audio_clkb";
+		};
+		audio_clkc {
+			compatible = "fixed-clock";
+			#clock-cells = <0x0>;
+			clock-frequency = <0x0>;
+			clock-output-names = "audio_clkc";
+		};
+
+		/* Special CPG clocks */
+		cpg_clocks: cpg_clocks@e6150000 {
+			compatible = "renesas,r8a7743-cpg-clocks",
+				     "renesas,rcar-gen2-cpg-clocks";
+			reg = <0 0xe6150000 0 0x1000>;
+			clocks = <&extal_clk>;
+			#clock-cells = <1>;
+			clock-output-names = "main", "pll0", "pll1", "pll3",
+					     "lb", "qspi", "sdh", "sd0";
+			#power-domain-cells = <0>;
+		};
+
+		/* Variable factor clocks */
+		sd2_clk: sd2_clk@e6150078 {
+			compatible = "renesas,r8a7743-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0x0 0xe6150078 0x0 0x4>;
+			clocks = <0x3>;
+			#clock-cells = <0x0>;
+			clock-output-names = "sd2";
+		};
+		sd3_clk: sd3_clk@e615026c {
+			compatible = "renesas,r8a7743-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0x0 0xe615026c 0x0 0x4>;
+			clocks = <0x3>;
+			#clock-cells = <0x0>;
+			clock-output-names = "sd3";
+		};
+		mmc0_clk: mmc0_clk@e6150240 {
+			compatible = "renesas,r8a7743-div6-clock",
+				     "renesas,cpg-div6-clock";
+			reg = <0x0 0xe6150240 0x0 0x4>;
+			clocks = <0x3>;
+			#clock-cells = <0x0>;
+			clock-output-names = "mmc0";
+		};
+
+		/* Fixed factor clocks */
+		pll1_div2_clk: pll1_div2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "pll1_div2";
+		};
+
+		z2: z2 {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL0>;
+			#clock-cells = <0>;
+			clock-div = <3>;
+			clock-mult = <1>;
+			clock-output-names = "z2";
+		};
+
+		zg_clk: zg_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <6>;
+			clock-mult = <1>;
+			clock-output-names = "zg";
+		};
+
+		zx_clk: zx_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <3>;
+			clock-mult = <1>;
+			clock-output-names = "zx";
+		};
+
+		zs_clk: zs_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <6>;
+			clock-mult = <1>;
+			clock-output-names = "zs";
+		};
+
+		/* Fixed factor clocks */
+		hp_clk: hp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <12>;
+			clock-mult = <1>;
+			clock-output-names = "hp";
+		};
+		i_clk: i_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "i";
+		};
+		b_clk: b_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <12>;
+			clock-mult = <1>;
+			clock-output-names = "b";
+		};
+		p_clk: p_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <24>;
+			clock-mult = <1>;
+			clock-output-names = "p";
+		};
+		cl_clk: cl_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <48>;
+			clock-mult = <1>;
+			clock-output-names = "cl";
+		};
+		m2_clk: m2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "m2";
+		};
+		imp_clk: imp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <4>;
+			clock-mult = <1>;
+			clock-output-names = "imp";
+		};
+		rclk_clk: rclk_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <(48 * 1024)>;
+			clock-mult = <1>;
+			clock-output-names = "rclk";
+		};
+		oscclk_clk: oscclk_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <(12 * 1024)>;
+			clock-mult = <1>;
+			clock-output-names = "oscclk";
+		};
+		zb3_clk: zb3_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <4>;
+			clock-mult = <1>;
+			clock-output-names = "zb3";
+		};
+		zb3d2_clk: zb3d2_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "zb3d2";
+		};
+		ddr_clk: ddr_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <8>;
+			clock-mult = <1>;
+			clock-output-names = "ddr";
+		};
+		mp_clk: mp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&pll1_div2_clk>;
+			#clock-cells = <0>;
+			clock-div = <15>;
+			clock-mult = <1>;
+			clock-output-names = "mp";
+		};
+		cp_clk: cp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&cpg_clocks R8A7743_CLK_PLL1>;
+			#clock-cells = <0>;
+			clock-div = <48>;
+			clock-mult = <1>;
+			clock-output-names = "cp";
+		};
+		acp_clk: acp_clk {
+			compatible = "fixed-factor-clock";
+			clocks = <&extal_clk>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+			clock-output-names = "acp";
+		};
+
+		/* Gate clocks */
+		mstp3_clks: mstp3_clks@e615013c {
+			compatible = "renesas,r8a7743-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe615013c 0 4>, <0 0xe6150048 0 4>;
+			clocks = <&cpg_clocks R8A7743_CLK_SD0>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7743_CLK_SDHI0>;
+			clock-output-names = "sdhi0";
+		};
+
+		mstp7_clks: mstp7_clks@e615014c {
+			compatible = "renesas,r8a7743-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe615014c 0 4>, <0 0xe61501c4 0 4>;
+			clocks = <&p_clk>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7743_CLK_SCIF4>;
+			clock-output-names = "scif4";
+		};
+
+		mstp9_clks: mstp9_clks@e6150994 {
+			compatible = "renesas,r8a7743-mstp-clocks",
+				     "renesas,cpg-mstp-clocks";
+			reg = <0 0xe6150994 0 4>, <0 0xe61509a4 0 4>;
+			clocks = <&hp_clk>;
+			#clock-cells = <1>;
+			clock-indices = <R8A7743_CLK_I2C2>;
+			clock-output-names = "i2c2";
+		};
+	};
+
+	vcc_sdhi0: regulator@0 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "SDHI0 Vcc";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		regulator-boot-on;
+		regulator-always-on;
+
+	};
+
+	vccq_sdhi0: regulator@1 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "SDHI0 VccQ";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gic: interrupt-controller@f1001000 {
+		compatible = "arm,cortex-a7-gic", "arm,cortex-a15-gic";
+		reg = <0x0 0xf1001000 0x0 0x1000>,
+		      <0x0 0xf1002000 0x0 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
+	sysc: system-controller@e6180000 {
+		compatible = "renesas,r8a7743-sysc";
+		reg = <0 0xe6180000 0 0x0200>;
+		#power-domain-cells = <1>;
+	};
+
+	pfc: pin-controller@e6060000 {
+		compatible = "renesas,pfc-r8a7743";
+		reg = <0x0 0xe6060000 0x0 0x11c>;
+		#gpio-range-cells = <0x3>;
+		linux,phandle = <0x7>;
+		phandle = <0x7>;
+
+		serial6 {
+			renesas,groups = "scif4_data_c";
+			renesas,function = "scif4";
+			linux,phandle = <0x12>;
+			phandle = <0x12>;
+		};
+
+		sdhi0_pins: sd0 {
+			renesas,groups = "sdhi0_data4", "sdhi0_ctrl",
+					 "sdhi0_cd", "sdhi0_wp";
+			renesas,function = "sdhi0";
+		};
+	};
+
+	scif4: serial@e6ee0000 {
+		compatible = "renesas,scif-r8a7743", "renesas,scif";
+		reg = <0 0xe6ee0000 0 0x40>;
+		interrupts = <0 24 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp7_clks R8A7743_CLK_SCIF4>;
+		clock-names = "sci_ick";
+		power-domains = <&sysc R8A7743_PD_ALWAYS_ON>;
+		status = "okay";
+		pinctrl-0 = <0x12>;
+		pinctrl-names = "default";
+	};
+
+	sdhi0: sd@ee100000 {
+		compatible = "renesas,sdhi-r8a7743";
+		reg = <0 0xee100000 0 0x200>;
+		interrupts = <0 165 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp3_clks R8A7743_CLK_SDHI0>;
+		power-domains = <&sysc R8A7743_PD_ALWAYS_ON>;
+		status = "okay";
+		vmmc-supply = <&vcc_sdhi0>;
+		vqmmc-supply = <&vccq_sdhi0>;
+	};
+
+	i2c2: i2c@e6530000 {
+		compatible = "renesas,i2c-r8a7743";
+		reg = <0 0xe6530000 0 0x40>;
+		interrupts = <0 286 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&mstp9_clks R8A7743_CLK_I2C2>;
+		power-domains = <&sysc R8A7743_PD_ALWAYS_ON>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "okay";
+	};
+};

--- a/configs/emtrion-rzg1e-linux-demo.c
+++ b/configs/emtrion-rzg1e-linux-demo.c
@@ -1,0 +1,163 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Configuration for linux-demo inmate on emCON-RZ/G1E:
+ * 1 CPU, 64M RAM, I2C bus I2C2, serial port SCIF4, SDHI0
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Ruediger Fichter <ruediger.fichter@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_cell_desc cell;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[11];
+	struct jailhouse_irqchip irqchips[3];
+	struct jailhouse_pci_device pci_devices[1];
+} __attribute__((packed)) config = {
+	.cell = {
+		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.name = "emtrion-emconrzg1e-linux-demo",
+		.flags = JAILHOUSE_CELL_PASSIVE_COMMREG,
+
+		.cpu_set_size = sizeof(config.cpus),
+		.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+		.num_irqchips = ARRAY_SIZE(config.irqchips),
+		/* .num_pci_devices = ARRAY_SIZE(config.pci_devices),
+		.vpci_irq_base = 123, */
+	},
+
+	.cpus = {
+		0x2,
+	},
+
+	.mem_regions = {
+		/* CPG (HACK) */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* RST, MODEMR */ {
+			.phys_start = 0xe6160060,
+			.virt_start = 0xe6160060,
+			.size = 0x4,
+			.flags = JAILHOUSE_MEM_READ |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* Generic Counter */ {
+			.phys_start = 0xe6080000,
+			.virt_start = 0xe6080000,
+			.size = 0x40,
+			.flags = JAILHOUSE_MEM_READ |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* PFC (HACK) */ {
+			.phys_start = 0xe6060000,
+			.virt_start = 0xe6060000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SYSC (HACK) */ {
+			.phys_start = 0xe6180000,
+			.virt_start = 0xe6180000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SCIF4 */ {
+			.phys_start = 0xe6ee0000,
+			.virt_start = 0xe6ee0000,
+			.size = 0x400,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32 |
+				JAILHOUSE_MEM_IO_16 | JAILHOUSE_MEM_IO_8,
+		},
+		/* SDHI0: SDC */ {
+			.phys_start = 0xee100000,
+			.virt_start = 0xee100000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C2 */ {
+			.phys_start = 0xe6530000,
+			.virt_start = 0xe6530000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* RAM */ {
+			.phys_start = 0x7bef0000,
+			.virt_start = 0,
+			.size = 0x10000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* RAM */ {
+			.phys_start = 0x70000000,
+			.virt_start = 0x70000000,
+			.size = 0xbef0000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_DMA |
+				JAILHOUSE_MEM_LOADABLE,
+		},
+		/* IVSHMEM shared memory region */ {
+			.phys_start = 0x7bf00000,
+			.virt_start = 0x7bf00000,
+			.size = 0x100000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_ROOTSHARED,
+		},
+	},
+
+	.irqchips = {
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 32,
+			.pin_bitmap = {
+				1 << (24+32 - 32), /* SCIF4 */
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 160,
+			.pin_bitmap = {
+				0, 1 << (165+32 - 192) /* SDHI0 */
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 288,
+			.pin_bitmap = {
+				1 << (286+32 - 288), /* I2C2 */
+			},
+		},
+	},
+
+	.pci_devices = {
+		/* 00:00.0 */ {
+			.type = JAILHOUSE_PCI_TYPE_IVSHMEM,
+			.bdf = 0x00,
+			.bar_mask = {
+				0xffffff00, 0xffffffff, 0x00000000,
+				0x00000000, 0x00000000, 0x00000000,
+			},
+			.shmem_region = 4,
+			.shmem_protocol = JAILHOUSE_SHMEM_PROTO_VETH,
+		},
+	},
+};

--- a/configs/emtrion-rzg1e-uart-demo.c
+++ b/configs/emtrion-rzg1e-uart-demo.c
@@ -1,0 +1,64 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Configuration for uart-demo inmate on emCON-RZ/G1E:
+ * 1 CPU, 64K RAM, serial ports SCIF4, CCU
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Ruediger Fichter <ruediger.fichter@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_cell_desc cell;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[3];
+} __attribute__((packed)) config = {
+	.cell = {
+		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.name = "emtrion-emconrzg1e-uart-demo",
+		.flags = JAILHOUSE_CELL_PASSIVE_COMMREG,
+
+		.cpu_set_size = sizeof(config.cpus),
+		.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+	},
+
+	.cpus = {
+		0x2,
+	},
+
+	.mem_regions = {
+		/* CPG (HACK) */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SCIF4 */ {
+			.phys_start = 0xe6ee0000,
+			.virt_start = 0xe6ee0000,
+			.size = 0x400,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_8 |
+				JAILHOUSE_MEM_IO_16 | JAILHOUSE_MEM_IO_32,
+		},
+		/* RAM */ {
+			.phys_start = 0x7bff0000,
+			.virt_start = 0,
+			.size = 0x00010000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+	}
+};

--- a/configs/emtrion-rzg1e.c
+++ b/configs/emtrion-rzg1e.c
@@ -1,0 +1,244 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Test configuration for emtrion's emCON-RZ/G1E board
+ * (RZ/G1E dual-core Cortex-A7, 1G RAM)
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Ruediger Fichter <ruediger.fichter@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_system header;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[19];
+	struct jailhouse_irqchip irqchips[3];
+	struct jailhouse_pci_device pci_devices[1];
+} __attribute__((packed)) config = {
+	.header = {
+		.signature = JAILHOUSE_SYSTEM_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.hypervisor_memory = {
+			.phys_start = 0x7c000000,
+			.size = 0x4000000,
+		},
+		.debug_console = {
+			.address = 0xe62d0000,
+			.size = 0x1000,
+			/* .clock_reg = 0xe615014c, */
+			/* .gate_nr = 13, */
+			/* .divider = 0x2e, */
+			.flags = JAILHOUSE_CON1_TYPE_HSCIF |
+				 JAILHOUSE_CON1_ACCESS_MMIO |
+				 JAILHOUSE_CON1_REGDIST_4 |
+				 JAILHOUSE_CON2_TYPE_ROOTPAGE,
+		},
+		.platform_info = {
+			/* .pci_mmconfig_base = 0x2000000,
+			.pci_mmconfig_end_bus = 0,
+			.pci_is_virtual = 1, */
+			.arm = {
+				.gic_version = 2,
+				.gicd_base = 0xf1001000,
+				.gicc_base = 0xf1002000,
+				.gich_base = 0xf1004000,
+				.gicv_base = 0xf1006000,
+				.maintenance_irq = 25,
+			},
+		},
+		.root_cell = {
+			.name = "emCON-RZ/G1E",
+			.cpu_set_size = sizeof(config.cpus),
+			.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+			.num_irqchips = ARRAY_SIZE(config.irqchips),
+			/* .num_pci_devices = ARRAY_SIZE(config.pci_devices),
+			.vpci_irq_base = 108, */
+		},
+	},
+
+	.cpus = {
+		0x3,
+	},
+
+	.mem_regions = {
+		/* CPG */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* APMU */ {
+			.phys_start = 0xe6151000,
+			.virt_start = 0xe6151000,
+			.size = 0xf000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* IRQC */ {
+			.phys_start = 0xe61c0000,
+			.virt_start = 0xe61c0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* CMT0 */ {
+			.phys_start = 0xffca0000,
+			.virt_start = 0xffca0000,
+			.size = 0x2000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* CMT1 */ {
+			.phys_start = 0xe6130000,
+			.virt_start = 0xe6130000,
+			.size = 0x2000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* TMU0 */ {
+			.phys_start = 0xe61e0000,
+			.virt_start = 0xe61e0000,
+			.size = 0x400,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* HSCIF2 */ {
+			.phys_start = 0xe62d0000,
+			.virt_start = 0xe62d0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* EtherAVB */ {
+			.phys_start = 0xe6800000,
+			.virt_start = 0xe6800000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* MMCIF: eMMC */ {
+			.phys_start = 0xee200000,
+			.virt_start = 0xee200000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* USB0 */ {
+			.phys_start = 0xee080000,
+			.virt_start = 0xee080000,
+			.size = 0x00020000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* VSPDU */ {
+			.phys_start = 0xfe930000,
+			.virt_start = 0xfe930000,
+			.size = 0x00008000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* DU */ {
+			.phys_start = 0xfeb00000,
+			.virt_start = 0xfeb00000,
+			.size = 0x00040000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* CAN0 */ {
+			.phys_start = 0xe6e80000,
+			.virt_start = 0xe6e80000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+			},
+		/* CAN1 */ {
+			.phys_start = 0xe6e88000,
+			.virt_start = 0xe6e88000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C0 */ {
+			.phys_start = 0xe6508000,
+			.virt_start = 0xe6508000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C1 */ {
+			.phys_start = 0xe6530000,
+			.virt_start = 0xe6530000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C2 */ {
+			.phys_start = 0xe6540000,
+			.virt_start = 0xe6540000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* RAM */ {
+			.phys_start = 0x40000000,
+			.virt_start = 0x40000000,
+			.size = 0x3bf00000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE,
+		},
+		/* IVSHMEM shared memory region */ {
+			.phys_start = 0x7bf00000,
+			.virt_start = 0x7bf00000,
+			.size = 0x100000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE,
+		},
+	},
+
+	.irqchips = {
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 32,
+			.pin_bitmap = {
+				0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 160,
+			.pin_bitmap = {
+				0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 288,
+			.pin_bitmap = {
+				0xffffffff
+			},
+		},
+	},
+
+	.pci_devices = {
+		/* 00:00.0 */ {
+			.type = JAILHOUSE_PCI_TYPE_IVSHMEM,
+			.bdf = 0x00,
+			.bar_mask = {
+				0xffffff00, 0xffffffff, 0x00000000,
+				0x00000000, 0x00000000, 0x00000000,
+			},
+			.shmem_region = 16,
+			.shmem_protocol = JAILHOUSE_SHMEM_PROTO_VETH,
+		},
+	},
+};

--- a/configs/emtrion-rzg1m-linux-demo.c
+++ b/configs/emtrion-rzg1m-linux-demo.c
@@ -1,0 +1,177 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Configuration for linux-demo inmate on emCON-RZ/G1M:
+ * 1 CPU, 64M RAM, I2C bus I2C2, serial port SCIF4, SDHI0
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Jan von Wiarda <jan.vonwiarda@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_cell_desc cell;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[13];
+	struct jailhouse_irqchip irqchips[3];
+	struct jailhouse_pci_device pci_devices[1];
+} __attribute__((packed)) config = {
+	.cell = {
+		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.name = "emtrion-emconrzg1m-linux-demo",
+		.flags = JAILHOUSE_CELL_PASSIVE_COMMREG,
+
+		.cpu_set_size = sizeof(config.cpus),
+		.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+		.num_irqchips = ARRAY_SIZE(config.irqchips),
+		/* .num_pci_devices = ARRAY_SIZE(config.pci_devices),
+		.vpci_irq_base = 123, */
+	},
+
+	.cpus = {
+		0x2,
+	},
+
+	.mem_regions = {
+		/* CPG (HACK) */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* RST, MODEMR */ {
+			.phys_start = 0xe6160060,
+			.virt_start = 0xe6160060,
+			.size = 0x4,
+			.flags = JAILHOUSE_MEM_READ |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* RST, CA15RESCNT */ {
+			.phys_start = 0xe6160040,
+			.virt_start = 0xe6160040,
+			.size = 0x4,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* IRQC */ {
+			.phys_start = 0xe61c0000,
+			.virt_start = 0xe61c0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* Generic Counter */ {
+			.phys_start = 0xe6080000,
+			.virt_start = 0xe6080000,
+			.size = 0x40,
+			.flags = JAILHOUSE_MEM_READ |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* PFC (HACK) */ {
+			.phys_start = 0xe6060000,
+			.virt_start = 0xe6060000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SYSC (HACK) */ {
+			.phys_start = 0xe6180000,
+			.virt_start = 0xe6180000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SCIF4 */ {
+			.phys_start = 0xe6ee0000,
+			.virt_start = 0xe6ee0000,
+			.size = 0x400,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32 |
+				JAILHOUSE_MEM_IO_16 | JAILHOUSE_MEM_IO_8,
+		},
+		/* SDHI0: SDC */ {
+			.phys_start = 0xee100000,
+			.virt_start = 0xee100000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C2 */ {
+			.phys_start = 0xe6530000,
+			.virt_start = 0xe6530000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* RAM */ {
+			.phys_start = 0x7bef0000,
+			.virt_start = 0,
+			.size = 0x10000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* RAM */ {
+			.phys_start = 0x70000000,
+			.virt_start = 0x70000000,
+			.size = 0xbef0000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_DMA |
+				JAILHOUSE_MEM_LOADABLE,
+		},
+		/* IVSHMEM shared memory region */ {
+			.phys_start = 0x7bf00000,
+			.virt_start = 0x7bf00000,
+			.size = 0x100000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_ROOTSHARED,
+		},
+	},
+
+	.irqchips = {
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 32,
+			.pin_bitmap = {
+				1 << (24+32 - 32), /* SCIF4 */
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 160,
+			.pin_bitmap = {
+				0, 1 << (165+32 - 192) /* SDHI0 */
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 288,
+			.pin_bitmap = {
+				1 << (286+32 - 288), /* I2C2 */
+			},
+		},
+	},
+
+	.pci_devices = {
+		/* 00:00.0 */ {
+			.type = JAILHOUSE_PCI_TYPE_IVSHMEM,
+			.bdf = 0x00,
+			.bar_mask = {
+				0xffffff00, 0xffffffff, 0x00000000,
+				0x00000000, 0x00000000, 0x00000000,
+			},
+			.shmem_region = 4,
+			.shmem_protocol = JAILHOUSE_SHMEM_PROTO_VETH,
+		},
+	},
+};

--- a/configs/emtrion-rzg1m-uart-demo.c
+++ b/configs/emtrion-rzg1m-uart-demo.c
@@ -1,0 +1,63 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Configuration for uart-demo inmate on emCON-RZ/G1M:
+ * 1 CPU, 64K RAM, serial ports SCIF4, CCU
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Jan von Wiarda <jan.vonwiarda@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_cell_desc cell;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[3];
+} __attribute__((packed)) config = {
+	.cell = {
+		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.name = "emtrion-emconrzg1m-uart-demo",
+		.flags = JAILHOUSE_CELL_PASSIVE_COMMREG,
+
+		.cpu_set_size = sizeof(config.cpus),
+		.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+	},
+
+	.cpus = {
+		0x2,
+	},
+
+	.mem_regions = {
+		/* CPG (HACK) */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* SCIF4 */ {
+			.phys_start = 0xe6ee0000,
+			.virt_start = 0xe6ee0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* RAM */ {
+			.phys_start = 0x7bff0000,
+			.virt_start = 0,
+			.size = 0x00010000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+	}
+};

--- a/configs/emtrion-rzg1m.c
+++ b/configs/emtrion-rzg1m.c
@@ -1,0 +1,272 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Test configuration for emtrion's emCON-RZ/G1M board
+ * (RZ/G1M dual-core Cortex-A15, 1G RAM)
+ *
+ * Copyright (c) emtrion GmbH, 2017
+ *
+ * Authors:
+ *  Jan von Wiarda <jan.vonwiarda@emtrion.de>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/types.h>
+#include <jailhouse/cell-config.h>
+
+#define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
+
+struct {
+	struct jailhouse_system header;
+	__u64 cpus[1];
+	struct jailhouse_memory mem_regions[23];
+	struct jailhouse_irqchip irqchips[3];
+	struct jailhouse_pci_device pci_devices[1];
+} __attribute__((packed)) config = {
+	.header = {
+		.signature = JAILHOUSE_SYSTEM_SIGNATURE,
+		.revision = JAILHOUSE_CONFIG_REVISION,
+		.hypervisor_memory = {
+			.phys_start = 0x7c000000,
+			.size = 0x4000000,
+		},
+		.debug_console = {
+			.address = 0xe62c0000,
+			.size = 0x1000,
+			/* .clock_reg = 0xe615014c, */
+			/* .gate_nr = 13, */
+			/* .divider = 0x2e, */
+			.flags = JAILHOUSE_CON1_TYPE_HSCIF |
+				 JAILHOUSE_CON1_ACCESS_MMIO |
+				 JAILHOUSE_CON1_REGDIST_4 |
+				 JAILHOUSE_CON2_TYPE_ROOTPAGE,
+		},
+		.platform_info = {
+			/* .pci_mmconfig_base = 0x2000000,
+			.pci_mmconfig_end_bus = 0,
+			.pci_is_virtual = 1, */
+			.arm = {
+				.gic_version = 2,
+				.gicd_base = 0xf1001000,
+				.gicc_base = 0xf1002000,
+				.gich_base = 0xf1004000,
+				.gicv_base = 0xf1006000,
+				.maintenance_irq = 25,
+			},
+		},
+		.root_cell = {
+			.name = "emCON-RZ/G1M",
+			.cpu_set_size = sizeof(config.cpus),
+			.num_memory_regions = ARRAY_SIZE(config.mem_regions),
+			.num_irqchips = ARRAY_SIZE(config.irqchips),
+			/* .num_pci_devices = ARRAY_SIZE(config.pci_devices),
+			.vpci_irq_base = 108, */
+		},
+	},
+
+	.cpus = {
+		0x3,
+	},
+
+	.mem_regions = {
+		/* Thermal Sensor */ {
+			.phys_start = 0xe61f0000,
+			.virt_start = 0xe61f0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* CPG */ {
+			.phys_start = 0xe6150000,
+			.virt_start = 0xe6150000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* APMU */ {
+			.phys_start = 0xe6151000,
+			.virt_start = 0xe6151000,
+			.size = 0xf000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* IRQC */ {
+			.phys_start = 0xe61c0000,
+			.virt_start = 0xe61c0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* CMT0 */ {
+			.phys_start = 0xffca0000,
+			.virt_start = 0xffca0000,
+			.size = 0x2000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* CMT1 */ {
+			.phys_start = 0xe6130000,
+			.virt_start = 0xe6130000,
+			.size = 0x2000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* TMU0 */ {
+			.phys_start = 0xe61e0000,
+			.virt_start = 0xe61e0000,
+			.size = 0x400,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO | JAILHOUSE_MEM_IO_32,
+		},
+		/* HSCIF0 */ {
+			.phys_start = 0xe62c0000,
+			.virt_start = 0xe62c0000,
+			.size = 0x1000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* EtherAVB */ {
+			.phys_start = 0xe6800000,
+			.virt_start = 0xe6800000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* MMCIF: eMMC */ {
+			.phys_start = 0xee200000,
+			.virt_start = 0xee200000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* USB0 */ {
+			.phys_start = 0xee080000,
+			.virt_start = 0xee080000,
+			.size = 0x00020000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* VSPDU */ {
+			.phys_start = 0xfe930000,
+			.virt_start = 0xfe930000,
+			.size = 0x00008000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* DU */ {
+			.phys_start = 0xfeb00000,
+			.virt_start = 0xfeb00000,
+			.size = 0x00040000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* CAN0 */ {
+			.phys_start = 0xe6e80000,
+			.virt_start = 0xe6e80000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* CAN1 */ {
+			.phys_start = 0xe6e88000,
+			.virt_start = 0xe6e88000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C0 */ {
+			.phys_start = 0xe6518000,
+			.virt_start = 0xe6518000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C1 */ {
+			.phys_start = 0xe6520000,
+			.virt_start = 0xe6520000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C2 */ {
+			.phys_start = 0xe6528000,
+			.virt_start = 0xe6528000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* I2C3 */ {
+			.phys_start = 0xe6530000,
+			.virt_start = 0xe6530000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* VSPD0 */ {
+			.phys_start = 0xfe930000,
+			.virt_start = 0xfe930000,
+			.size = 0x00008000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* VSPD1 */ {
+			.phys_start = 0xfe938000,
+			.virt_start = 0xfe938000,
+			.size = 0x00008000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_IO,
+		},
+		/* RAM */ {
+			.phys_start = 0x40000000,
+			.virt_start = 0x40000000,
+			.size = 0x3bf00000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE,
+		},
+		/* IVSHMEM shared memory region */ {
+			.phys_start = 0x7bf00000,
+			.virt_start = 0x7bf00000,
+			.size = 0x100000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE,
+		},
+	},
+
+	.irqchips = {
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 32,
+			.pin_bitmap = {
+				0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 160,
+			.pin_bitmap = {
+				0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+			},
+		},
+		/* GIC */ {
+			.address = 0xf1001000,
+			.pin_base = 288,
+			.pin_bitmap = {
+				0xffffffff
+			},
+		},
+	},
+
+	.pci_devices = {
+		/* 00:00.0 */ {
+			.type = JAILHOUSE_PCI_TYPE_IVSHMEM,
+			.bdf = 0x00,
+			.bar_mask = {
+				0xffffff00, 0xffffffff, 0x00000000,
+				0x00000000, 0x00000000, 0x00000000,
+			},
+			.shmem_region = 16,
+			.shmem_protocol = JAILHOUSE_SHMEM_PROTO_VETH,
+		},
+	},
+};

--- a/configs/hikey.c
+++ b/configs/hikey.c
@@ -18,7 +18,7 @@
 struct {
 	struct jailhouse_system header;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -88,6 +88,14 @@ struct {
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE,
 		},
+		/* SRAM */ {
+			.phys_start = 0xfff80000,
+			.virt_start = 0xfff80000,
+			.size = 0x12000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_EXECUTE,
+		},
+	
 		/* IVSHMEM shared memory region */ {
 			.phys_start = 0x7bf00000,
 			.virt_start = 0x7bf00000,


### PR DESCRIPTION
The sram@fff80000 region for Hi6220-HiKey was missing in the
configuration file and was causing errors in Linux kernel 4.9 used for
Linaro Reference Platform Build (RPB).

Signed-off-by: Mahdi Amiri K <mahdi@cs.otago.ac.nz>