### PR TITLE
setup-on-zynqmp-zcu102.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.dtb
 *.dtb.S
 *.dtb.*.tmp
+*.8
 Module.symvers
 modules.order
 driver/jailhouse.ko

--- a/Documentation/hypervisor-interfaces.txt
+++ b/Documentation/hypervisor-interfaces.txt
@@ -285,11 +285,15 @@ Communication region layout
 - - - - - - - - - - - - - -
 
     +------------------------------+ - begin of communication region
-    |   Message to Cell (32 bit)   |   (lower address)
+    |  Signature "JHCOMM" (6 byte) |   (lower address)
     +------------------------------+
-    |  Message from Cell (32 bit)  |
+    |     ABI Revision (16 bit)    |
     +------------------------------+
     |     Cell State (32 bit)      |
+    +------------------------------+
+    |   Message to Cell (32 bit)   |
+    +------------------------------+
+    |  Message from Cell (32 bit)  |
     +------------------------------+
     |      Reserved (32 bit)       |
     +------------------------------+
@@ -300,6 +304,10 @@ All fields use the native endianness of the system. The format is of the
 Platform Information part is architecture-specific. Its content is filled by
 the hypervisor during cell creation and shall be considered read-only until
 cell destruction.
+
+The ABI revision described here is 0. Future versions may not use a compatible
+layout or field semantic, except for the fields "Signature", "ABI Revision" and
+"Cell State".
 
 
 Logical Channel "Message"
@@ -370,6 +378,7 @@ defined:
  - Running, cell configurations locked (code 1)
  - Shut down (code 2), terminal state
  - Failed (code 3), terminal state
+ - Communication region ABI mismatch (code 4), terminal state
 
 Once a cell declared to have reached a terminal state, the hypervisor is free
 to destroy or restart that cell. On restart, it will also reset the state field

--- a/configs/arm/bananapi-gic-demo.c
+++ b/configs/arm/bananapi-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -65,6 +65,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm/bananapi-linux-demo.c
+++ b/configs/arm/bananapi-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[5];
+	struct jailhouse_memory mem_regions[6];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -79,6 +79,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/bananapi-uart-demo.c
+++ b/configs/arm/bananapi-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[3];
+	struct jailhouse_memory mem_regions[4];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -58,6 +58,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm/emtrion-rzg1e-linux-demo.c
+++ b/configs/arm/emtrion-rzg1e-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[10];
+	struct jailhouse_memory mem_regions[11];
 	struct jailhouse_irqchip irqchips[3];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -114,6 +114,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/emtrion-rzg1e-uart-demo.c
+++ b/configs/arm/emtrion-rzg1e-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -52,6 +52,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm/emtrion-rzg1h-linux-demo.c
+++ b/configs/arm/emtrion-rzg1h-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[12];
+	struct jailhouse_memory mem_regions[13];
 	struct jailhouse_irqchip irqchips[3];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -128,6 +128,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/emtrion-rzg1h-uart-demo.c
+++ b/configs/arm/emtrion-rzg1h-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -51,6 +51,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm/emtrion-rzg1m-linux-demo.c
+++ b/configs/arm/emtrion-rzg1m-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[12];
+	struct jailhouse_memory mem_regions[13];
 	struct jailhouse_irqchip irqchips[3];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -128,6 +128,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/emtrion-rzg1m-uart-demo.c
+++ b/configs/arm/emtrion-rzg1m-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -51,6 +51,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm/jetson-tk1-demo.c
+++ b/configs/arm/jetson-tk1-demo.c
@@ -25,7 +25,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -58,5 +58,11 @@ struct {
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
 		},
+                /* communication region */ {
+                        .virt_start = 0x80000000,
+                        .size = 0x00001000,
+                        .flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+                                JAILHOUSE_MEM_COMM_REGION,
+                },
 	},
 };

--- a/configs/arm/jetson-tk1-linux-demo.c
+++ b/configs/arm/jetson-tk1-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[2];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -74,6 +74,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/orangepi0-gic-demo.c
+++ b/configs/arm/orangepi0-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[3];
+	struct jailhouse_memory mem_regions[4];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -58,6 +58,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm/orangepi0-linux-demo.c
+++ b/configs/arm/orangepi0-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -72,6 +72,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/vexpress-gic-demo.c
+++ b/configs/arm/vexpress-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm/vexpress-linux-demo.c
+++ b/configs/arm/vexpress-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 	struct jailhouse_irqchip irqchips[1];
 } __attribute__((packed)) config = {
 	.cell = {
@@ -55,6 +55,12 @@ struct {
 			.size = 0x10000000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm/vexpress-uart-demo.c
+++ b/configs/arm/vexpress-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/amd-seattle-gic-demo.c
+++ b/configs/arm64/amd-seattle-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/amd-seattle-linux-demo.c
+++ b/configs/arm64/amd-seattle-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[8];
+	struct jailhouse_memory mem_regions[9];
 	struct jailhouse_irqchip irqchips[2];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -99,6 +99,12 @@ struct {
 			.size =           0x1000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_IO |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/amd-seattle-uart-demo.c
+++ b/configs/arm64/amd-seattle-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/espressobin-gic-demo.c
+++ b/configs/arm64/espressobin-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/espressobin-linux-demo.c
+++ b/configs/arm64/espressobin-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -72,6 +72,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/foundation-v8-gic-demo.c
+++ b/configs/arm64/foundation-v8-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm64/foundation-v8-linux-demo.c
+++ b/configs/arm64/foundation-v8-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 	struct jailhouse_irqchip irqchips[1];
 } __attribute__((packed)) config = {
 	.cell = {
@@ -63,6 +63,12 @@ struct {
 			.size = 0x10000000,	/* 256 MiB */
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/foundation-v8-uart-demo.c
+++ b/configs/arm64/foundation-v8-uart-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/hikey-gic-demo.c
+++ b/configs/arm64/hikey-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/hikey-linux-demo.c
+++ b/configs/arm64/hikey-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -72,6 +72,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/imx8mq-gic-demo.c
+++ b/configs/arm64/imx8mq-gic-demo.c
@@ -18,7 +18,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -51,6 +51,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/jetson-tx1-demo.c
+++ b/configs/arm64/jetson-tx1-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -51,6 +51,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm64/jetson-tx1-linux-demo.c
+++ b/configs/arm64/jetson-tx1-linux-demo.c
@@ -27,7 +27,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[2];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -82,6 +82,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/jetson-tx2-demo.c
+++ b/configs/arm64/jetson-tx2-demo.c
@@ -16,7 +16,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -46,6 +46,12 @@ struct {
 			.size = 0x1000000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 };

--- a/configs/arm64/qemu-arm64-gic-demo.c
+++ b/configs/arm64/qemu-arm64-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/qemu-arm64-linux-demo.c
+++ b/configs/arm64/qemu-arm64-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[1];
 } __attribute__((packed)) config = {
@@ -73,6 +73,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/zynqmp-zcu102-gic-demo.c
+++ b/configs/arm64/zynqmp-zcu102-gic-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[2];
+	struct jailhouse_memory mem_regions[3];
 } __attribute__((packed)) config = {
 	.cell = {
 		.signature = JAILHOUSE_CELL_DESC_SIGNATURE,
@@ -54,6 +54,12 @@ struct {
 			.size = 0x00010000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_EXECUTE | JAILHOUSE_MEM_LOADABLE,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	}
 };

--- a/configs/arm64/zynqmp-zcu102-linux-demo-2.c
+++ b/configs/arm64/zynqmp-zcu102-linux-demo-2.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[4];
+	struct jailhouse_memory mem_regions[5];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[2];
 } __attribute__((packed)) config = {
@@ -72,6 +72,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/configs/arm64/zynqmp-zcu102-linux-demo.c
+++ b/configs/arm64/zynqmp-zcu102-linux-demo.c
@@ -21,7 +21,7 @@
 struct {
 	struct jailhouse_cell_desc cell;
 	__u64 cpus[1];
-	struct jailhouse_memory mem_regions[5];
+	struct jailhouse_memory mem_regions[6];
 	struct jailhouse_irqchip irqchips[1];
 	struct jailhouse_pci_device pci_devices[2];
 } __attribute__((packed)) config = {
@@ -79,6 +79,12 @@ struct {
 			.size = 0x100000,
 			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
 				JAILHOUSE_MEM_ROOTSHARED,
+		},
+		/* communication region */ {
+			.virt_start = 0x80000000,
+			.size = 0x00001000,
+			.flags = JAILHOUSE_MEM_READ | JAILHOUSE_MEM_WRITE |
+				JAILHOUSE_MEM_COMM_REGION,
 		},
 	},
 

--- a/driver/pci.c
+++ b/driver/pci.c
@@ -17,7 +17,9 @@
 #include <linux/of_fdt.h>
 #include <linux/vmalloc.h>
 #include <linux/version.h>
+#ifdef CONFIG_OF_OVERLAY
 #include <dt-bindings/interrupt-controller/arm-gic.h>
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0)
 #define of_overlay_apply(overlay, id)	(*id = of_overlay_create(overlay))

--- a/driver/sysfs.c
+++ b/driver/sysfs.c
@@ -215,6 +215,8 @@ static ssize_t state_show(struct kobject *kobj, struct kobj_attribute *attr,
 		return sprintf(buffer, "shut down\n");
 	case JAILHOUSE_CELL_FAILED:
 		return sprintf(buffer, "failed\n");
+	case JAILHOUSE_CELL_FAILED_COMM_REV:
+		return sprintf(buffer, "Comm ABI mismatch\n");
 	default:
 		return sprintf(buffer, "invalid\n");
 	}

--- a/hypervisor/arch/arm64/Kbuild
+++ b/hypervisor/arch/arm64/Kbuild
@@ -20,4 +20,4 @@ always := lib.a
 # irqchip (common-objs-y), <generic units>
 
 lib-y := $(common-objs-y)
-lib-y += entry.o setup.o control.o mmio.o caches.o traps.o
+lib-y += entry.o setup.o control.o mmio.o paging.o caches.o traps.o

--- a/hypervisor/arch/arm64/asm-defines.c
+++ b/hypervisor/arch/arm64/asm-defines.c
@@ -27,6 +27,7 @@ void common(void)
 	       debug_console.address);
 	OFFSET(SYSCONFIG_HYPERVISOR_PHYS, jailhouse_system,
 	       hypervisor_memory.phys_start);
+	OFFSET(PERCPU_ID_AA64MMFR0, per_cpu, id_aa64mmfr0);
 	BLANK();
 
 	DEFINE(PERCPU_STACK_END,

--- a/hypervisor/arch/arm64/entry.S
+++ b/hypervisor/arch/arm64/entry.S
@@ -157,6 +157,9 @@ el2_entry:
 	 */
 	sub	sp, sp, 20 * 8
 
+	mrs	x29, id_aa64mmfr0_el1
+	str	x29, [x1, #PERCPU_ID_AA64MMFR0]
+
 	mov	x29, xzr	/* reset fp,lr */
 	mov	x30, xzr
 

--- a/hypervisor/arch/arm64/include/asm/paging.h
+++ b/hypervisor/arch/arm64/include/asm/paging.h
@@ -178,32 +178,7 @@ typedef u64 *pt_entry_t;
 
 extern unsigned int cpu_parange;
 
-/* return the bits supported for the physical address range for this
- * machine; in arch_paging_init this value will be kept in
- * cpu_parange for later reference */
-static inline unsigned int get_cpu_parange(void)
-{
-	unsigned long id_aa64mmfr0;
-
-	arm_read_sysreg(ID_AA64MMFR0_EL1, id_aa64mmfr0);
-
-	switch (id_aa64mmfr0 & 0xf) {
-	case PARANGE_32B:
-		return 32;
-	case PARANGE_36B:
-		return 36;
-	case PARANGE_40B:
-		return 40;
-	case PARANGE_42B:
-		return 42;
-	case PARANGE_44B:
-		return 44;
-	case PARANGE_48B:
-		return 48;
-	default:
-		return 0;
-	}
-}
+unsigned int get_cpu_parange(void);
 
 /* The size of the cpu_parange, determines from which level we can
  * start from the S2 translations, and the size of the first level

--- a/hypervisor/arch/arm64/include/asm/percpu.h
+++ b/hypervisor/arch/arm64/include/asm/percpu.h
@@ -34,6 +34,7 @@ struct per_cpu {
 	u32 stats[JAILHOUSE_NUM_CPU_STATS];
 	int shutdown_state;
 	bool failed;
+	unsigned long id_aa64mmfr0;
 
 	struct pending_irqs pending_irqs;
 

--- a/hypervisor/arch/arm64/paging.c
+++ b/hypervisor/arch/arm64/paging.c
@@ -1,0 +1,58 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Copyright 2018 NXP
+ *
+ * Authors:
+ *   Peng Fan <peng.fan@nxp.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <jailhouse/control.h>
+#include <asm/percpu.h>
+#include <asm/paging.h>
+
+/**
+ * Return the physical address bits.
+ *
+ * In arch_paging_init this value will be kept in cpu_parange
+ * for later reference
+ *
+ * @return The physical address bits.
+ */
+unsigned int get_cpu_parange(void)
+{
+	/* Larger than any possible value */
+	unsigned int parange = 0x10;
+	unsigned int cpu;
+
+	/*
+	 * early_init calls paging_init, which will indirectly call
+	 * get_cpu_parange, prior to cell_init, we cannot use
+	 * for_each_cpu yet. So we need to iterate over the configuration
+	 * of the root cell.
+	 */
+	for (cpu = 0; cpu < system_config->root_cell.cpu_set_size * 8; cpu++)
+		if (cpu_id_valid(cpu) &&
+		    (per_cpu(cpu)->id_aa64mmfr0 & 0xf) < parange)
+			parange = per_cpu(cpu)->id_aa64mmfr0 & 0xf;
+
+	switch (parange) {
+	case PARANGE_32B:
+		return 32;
+	case PARANGE_36B:
+		return 36;
+	case PARANGE_40B:
+		return 40;
+	case PARANGE_42B:
+		return 42;
+	case PARANGE_44B:
+		return 44;
+	case PARANGE_48B:
+		return 48;
+	default:
+		return 0;
+	}
+}

--- a/hypervisor/arch/x86/include/asm/processor.h
+++ b/hypervisor/arch/x86/include/asm/processor.h
@@ -143,6 +143,8 @@
 
 #define X86_REX_CODE					4
 
+#define X86_PREFIX_ADDR_SZ				0x67
+
 #define X86_OP_MOVZX_OPC1				0x0f
 #define X86_OP_MOVZX_OPC2_B				0xb6
 #define X86_OP_MOVZX_OPC2_W				0xb7

--- a/hypervisor/arch/x86/include/asm/processor.h
+++ b/hypervisor/arch/x86/include/asm/processor.h
@@ -150,6 +150,7 @@
 #define X86_OP_MOVZX_OPC2_W				0xb7
 #define X86_OP_MOVB_TO_MEM				0x88
 #define X86_OP_MOV_TO_MEM				0x89
+#define X86_OP_MOVB_FROM_MEM				0x8a
 #define X86_OP_MOV_FROM_MEM				0x8b
 #define X86_OP_MOV_IMMEDIATE_TO_MEM			0xc7
 #define X86_OP_MOV_MEM_TO_AX    			0xa1

--- a/hypervisor/arch/x86/include/asm/svm.h
+++ b/hypervisor/arch/x86/include/asm/svm.h
@@ -44,7 +44,7 @@
 
 struct svm_segment {
 	u16 selector;
-	u16 access_rights;
+	u16 attributes;
 	u32 limit;
 	u64 base;
 } __attribute__((packed));

--- a/hypervisor/arch/x86/include/asm/vcpu.h
+++ b/hypervisor/arch/x86/include/asm/vcpu.h
@@ -93,10 +93,14 @@ void vcpu_skip_emulated_instruction(unsigned int inst_len);
 void vcpu_vendor_get_cell_io_bitmap(struct cell *cell,
 		                    struct vcpu_io_bitmap *out);
 
+#define VCPU_CS_DPL_MASK	BIT_MASK(6, 5)
+#define VCPU_CS_L		(1 << 13)
+#define VCPU_CS_DB		(1 << 14)
+
 u64 vcpu_vendor_get_efer(void);
 u64 vcpu_vendor_get_rflags(void);
 u64 vcpu_vendor_get_rip(void);
-u16 vcpu_vendor_get_cs(void);
+u16 vcpu_vendor_get_cs_attr(void);
 
 void vcpu_vendor_get_io_intercept(struct vcpu_io_intercept *io);
 void vcpu_vendor_get_mmio_intercept(struct vcpu_mmio_intercept *mmio);

--- a/hypervisor/arch/x86/mmio.c
+++ b/hypervisor/arch/x86/mmio.c
@@ -128,6 +128,9 @@ restart:
 		inst.access_size = has_rex_w ? 8 : 4;
 		does_write = true;
 		break;
+	case X86_OP_MOVB_FROM_MEM:
+		inst.access_size = 1;
+		break;
 	case X86_OP_MOV_FROM_MEM:
 		inst.access_size = has_rex_w ? 8 : 4;
 		break;

--- a/hypervisor/arch/x86/mmio.c
+++ b/hypervisor/arch/x86/mmio.c
@@ -69,14 +69,22 @@ static bool ctx_update(struct parse_context *ctx, u64 *pc, unsigned int advance,
 	return true;
 }
 
+static unsigned int get_address_width(bool has_addrsz_prefix)
+{
+	u16 cs_attr = vcpu_vendor_get_cs_attr();
+	bool long_mode = (vcpu_vendor_get_efer() & EFER_LMA) &&
+		(cs_attr & VCPU_CS_L);
+
+	return long_mode ? (has_addrsz_prefix ? 4 : 8) :
+		(!!(cs_attr & VCPU_CS_DB) ^ has_addrsz_prefix) ? 4 : 2;
+}
+
 struct mmio_instruction
 x86_mmio_parse(const struct guest_paging_structures *pg_structs, bool is_write)
 {
 	struct parse_context ctx = { .remaining = X86_MAX_INST_LEN,
 				     .count = 1 };
 	union registers *guest_regs = &this_cpu_data()->guest_regs;
-	bool long_mode = (vcpu_vendor_get_efer() & EFER_LMA) &&
-		(vcpu_vendor_get_cs_attr() & VCPU_CS_L);
 	struct mmio_instruction inst = { .inst_len = 0 };
 	u64 pc = vcpu_vendor_get_rip();
 	unsigned int n, skip_len = 0;
@@ -141,12 +149,12 @@ restart:
 		does_write = true;
 		break;
 	case X86_OP_MOV_MEM_TO_AX:
-		inst.inst_len += (long_mode ^ has_addrsz_prefix) ? 8 : 4;
+		inst.inst_len += get_address_width(has_addrsz_prefix);
 		inst.access_size = has_rex_w ? 8 : 4;
 		inst.in_reg_num = 15;
 		goto final;
 	case X86_OP_MOV_AX_TO_MEM:
-		inst.inst_len += (long_mode ^ has_addrsz_prefix) ? 8 : 4;
+		inst.inst_len += get_address_width(has_addrsz_prefix);
 		inst.access_size = has_rex_w ? 8 : 4;
 		inst.out_val = guest_regs->by_index[15];
 		does_write = true;

--- a/hypervisor/arch/x86/mmio.c
+++ b/hypervisor/arch/x86/mmio.c
@@ -75,7 +75,8 @@ x86_mmio_parse(const struct guest_paging_structures *pg_structs, bool is_write)
 	struct parse_context ctx = { .remaining = X86_MAX_INST_LEN,
 				     .count = 1 };
 	union registers *guest_regs = &this_cpu_data()->guest_regs;
-	bool addr64 = !!(vcpu_vendor_get_efer() & EFER_LMA);
+	bool long_mode = (vcpu_vendor_get_efer() & EFER_LMA) &&
+		(vcpu_vendor_get_cs_attr() & VCPU_CS_L);
 	struct mmio_instruction inst = { .inst_len = 0 };
 	u64 pc = vcpu_vendor_get_rip();
 	unsigned int n, skip_len = 0;
@@ -140,12 +141,12 @@ restart:
 		does_write = true;
 		break;
 	case X86_OP_MOV_MEM_TO_AX:
-		inst.inst_len += (addr64 ^ has_addrsz_prefix) ? 8 : 4;
+		inst.inst_len += (long_mode ^ has_addrsz_prefix) ? 8 : 4;
 		inst.access_size = has_rex_w ? 8 : 4;
 		inst.in_reg_num = 15;
 		goto final;
 	case X86_OP_MOV_AX_TO_MEM:
-		inst.inst_len += (addr64 ^ has_addrsz_prefix) ? 8 : 4;
+		inst.inst_len += (long_mode ^ has_addrsz_prefix) ? 8 : 4;
 		inst.access_size = has_rex_w ? 8 : 4;
 		inst.out_val = guest_regs->by_index[15];
 		does_write = true;

--- a/hypervisor/arch/x86/svm.c
+++ b/hypervisor/arch/x86/svm.c
@@ -1043,9 +1043,17 @@ VCPU_VENDOR_GET_REGISTER(efer);
 VCPU_VENDOR_GET_REGISTER(rflags);
 VCPU_VENDOR_GET_REGISTER(rip);
 
-u16 vcpu_vendor_get_cs(void)
+u16 vcpu_vendor_get_cs_attr(void)
 {
-	return this_cpu_data()->vmcb.cs.selector;
+	/*
+	 * Build the CS segment attributes from the L and D/B extracted from
+	 * the segment attribute field and the CPL from its own field. The
+	 * latter is suggested by the AMD spec (Vol 2, 15.5.1). Present the
+	 * result in Intel format.
+	 */
+	u16 l_db = this_cpu_data()->vmcb.cs.attributes & BIT_MASK(10, 9);
+
+	return (this_cpu_data()->vmcb.cpl << 5) | (l_db << 4);
 }
 
 /* GIF must be set for interrupts to be delivered (APMv2, Sect. 15.17) */

--- a/hypervisor/arch/x86/svm.c
+++ b/hypervisor/arch/x86/svm.c
@@ -134,7 +134,7 @@ static void set_svm_segment_from_segment(struct svm_segment *svm_segment,
 					 const struct segment *segment)
 {
 	svm_segment->selector = segment->selector;
-	svm_segment->access_rights = ((segment->access_rights & 0xf000) >> 4) |
+	svm_segment->attributes = ((segment->access_rights & 0xf000) >> 4) |
 		(segment->access_rights & 0x00ff);
 	svm_segment->limit = segment->limit;
 	svm_segment->base = segment->base;
@@ -554,13 +554,13 @@ void vcpu_vendor_reset(unsigned int sipi_vector)
 		.selector = 0,
 		.base = 0,
 		.limit = 0xffff,
-		.access_rights = 0x0093,
+		.attributes = 0x0093,
 	};
 	static const struct svm_segment dtr_reset_state = {
 		.selector = 0,
 		.base = 0,
 		.limit = 0xffff,
-		.access_rights = 0,
+		.attributes = 0,
 	};
 	struct per_cpu *cpu_data = this_cpu_data();
 	struct vmcb *vmcb = &cpu_data->vmcb;
@@ -588,7 +588,7 @@ void vcpu_vendor_reset(unsigned int sipi_vector)
 	}
 
 	vmcb->cs.limit = 0xffff;
-	vmcb->cs.access_rights = 0x009b;
+	vmcb->cs.attributes = 0x009b;
 
 	vmcb->ds = dataseg_reset_state;
 	vmcb->es = dataseg_reset_state;
@@ -599,12 +599,12 @@ void vcpu_vendor_reset(unsigned int sipi_vector)
 	vmcb->tr.selector = 0;
 	vmcb->tr.base = 0;
 	vmcb->tr.limit = 0xffff;
-	vmcb->tr.access_rights = 0x008b;
+	vmcb->tr.attributes = 0x008b;
 
 	vmcb->ldtr.selector = 0;
 	vmcb->ldtr.base = 0;
 	vmcb->ldtr.limit = 0xffff;
-	vmcb->ldtr.access_rights = 0x0082;
+	vmcb->ldtr.attributes = 0x0082;
 
 	vmcb->gdtr = dtr_reset_state;
 	vmcb->idtr = dtr_reset_state;
@@ -849,7 +849,7 @@ static void dump_guest_regs(union registers *guest_regs, struct vmcb *vmcb)
 	panic_printk("RDX: 0x%016lx RSI: 0x%016lx RDI: 0x%016lx\n",
 		     guest_regs->rdx, guest_regs->rsi, guest_regs->rdi);
 	panic_printk("CS: %x BASE: 0x%016llx AR-BYTES: %x EFER.LMA %d\n",
-		     vmcb->cs.selector, vmcb->cs.base, vmcb->cs.access_rights,
+		     vmcb->cs.selector, vmcb->cs.base, vmcb->cs.attributes,
 		     !!(vmcb->efer & EFER_LMA));
 	panic_printk("CR0: 0x%016llx CR3: 0x%016llx CR4: 0x%016llx\n",
 		     vmcb->cr0, vmcb->cr3, vmcb->cr4);

--- a/hypervisor/arch/x86/vmx.c
+++ b/hypervisor/arch/x86/vmx.c
@@ -1250,9 +1250,9 @@ VCPU_VENDOR_GET_REGISTER(efer, GUEST_IA32_EFER);
 VCPU_VENDOR_GET_REGISTER(rflags, GUEST_RFLAGS);
 VCPU_VENDOR_GET_REGISTER(rip, GUEST_RIP);
 
-u16 vcpu_vendor_get_cs(void)
+u16 vcpu_vendor_get_cs_attr(void)
 {
-	return vmcs_read16(GUEST_CS_SELECTOR);
+	return vmcs_read32(GUEST_CS_AR_BYTES);
 }
 
 void enable_irq(void)

--- a/hypervisor/control.c
+++ b/hypervisor/control.c
@@ -695,6 +695,7 @@ static int cell_get_state(struct per_cpu *cpu_data, unsigned long id)
 			case JAILHOUSE_CELL_RUNNING_LOCKED:
 			case JAILHOUSE_CELL_SHUT_DOWN:
 			case JAILHOUSE_CELL_FAILED:
+			case JAILHOUSE_CELL_FAILED_COMM_REV:
 				return state;
 			default:
 				return -EINVAL;

--- a/hypervisor/control.c
+++ b/hypervisor/control.c
@@ -341,6 +341,7 @@ static int cell_create(struct per_cpu *cpu_data, unsigned long config_address)
 {
 	unsigned long cfg_page_offs = config_address & ~PAGE_MASK;
 	unsigned int cfg_pages, cell_pages, cpu, n;
+	struct jailhouse_comm_region *comm_region;
 	const struct jailhouse_memory *mem;
 	struct jailhouse_cell_desc *cfg;
 	unsigned long cfg_total_size;
@@ -475,7 +476,11 @@ static int cell_create(struct per_cpu *cpu_data, unsigned long config_address)
 
 	config_commit(cell);
 
-	cell->comm_page.comm_region.cell_state = JAILHOUSE_CELL_SHUT_DOWN;
+	comm_region = &cell->comm_page.comm_region;
+	memcpy(comm_region->signature, COMM_REGION_MAGIC,
+	       sizeof(comm_region->signature));
+	comm_region->revision = COMM_REGION_ABI_REVISION;
+	comm_region->cell_state = JAILHOUSE_CELL_SHUT_DOWN;
 
 	last = &root_cell;
 	while (last->next)

--- a/include/jailhouse/hypercall.h
+++ b/include/jailhouse/hypercall.h
@@ -88,6 +88,7 @@
 #define JAILHOUSE_CELL_RUNNING_LOCKED		1
 #define JAILHOUSE_CELL_SHUT_DOWN		2 /* terminal state */
 #define JAILHOUSE_CELL_FAILED			3 /* terminal state */
+#define JAILHOUSE_CELL_FAILED_COMM_REV		4 /* terminal state */
 
 #define COMM_REGION_ABI_REVISION		0
 #define COMM_REGION_MAGIC			"JHCOMM"

--- a/include/jailhouse/hypercall.h
+++ b/include/jailhouse/hypercall.h
@@ -89,13 +89,20 @@
 #define JAILHOUSE_CELL_SHUT_DOWN		2 /* terminal state */
 #define JAILHOUSE_CELL_FAILED			3 /* terminal state */
 
+#define COMM_REGION_ABI_REVISION		0
+#define COMM_REGION_MAGIC			"JHCOMM"
+
 #define COMM_REGION_GENERIC_HEADER					\
+	/** Communication region magic JHCOMM */			\
+	char signature[6];						\
+	/** Communication region ABI revision */			\
+	__u16 revision;							\
+	/** Cell state, initialized by hypervisor, updated by cell. */	\
+	volatile __u32 cell_state;					\
 	/** Message code sent from hypervisor to cell. */		\
 	volatile __u32 msg_to_cell;					\
 	/** Reply code sent from cell to hypervisor. */			\
 	volatile __u32 reply_from_cell;					\
-	/** Cell state, initialized by hypervisor, updated by cell. */	\
-	volatile __u32 cell_state;					\
 	/** \privatesection */						\
 	volatile __u32 padding;						\
 	/** \publicsection */

--- a/inmates/Makefile
+++ b/inmates/Makefile
@@ -28,6 +28,7 @@ KBUILD_CFLAGS := -g -Os -Wall -Wstrict-prototypes -Wtype-limits \
 		 -Wmissing-declarations -Wmissing-prototypes \
 		 -fno-strict-aliasing -fomit-frame-pointer -fno-pic \
 		 -fno-common -fno-stack-protector -ffreestanding \
+		 -ffunction-sections \
 		 -D__LINUX_COMPILER_TYPES_H
 ifneq ($(wildcard $(INC_CONFIG_H)),)
 KBUILD_CFLAGS += -include $(INC_CONFIG_H)

--- a/inmates/demos/arm/gic-demo.c
+++ b/inmates/demos/arm/gic-demo.c
@@ -68,6 +68,5 @@ void inmate_main(void)
 	led_reg = (void *)(unsigned long)cmdline_parse_int("led-reg", 0);
 	led_pin = cmdline_parse_int("led-pin", 0);
 
-	while (1)
-		asm volatile("wfi" : : : "memory");
+	halt();
 }

--- a/inmates/demos/x86/ioapic-demo.c
+++ b/inmates/demos/x86/ioapic-demo.c
@@ -54,6 +54,5 @@ void inmate_main(void)
 	printk("Note: ACPI IRQs are broken for Linux now.\n");
 	asm volatile("sti");
 
-	while (1)
-		asm volatile("hlt");
+	halt();
 }

--- a/inmates/demos/x86/ivshmem-demo.c
+++ b/inmates/demos/x86/ivshmem-demo.c
@@ -166,5 +166,5 @@ void inmate_main(void)
 		}
 	}
 out:
-	asm volatile("hlt");
+	halt();
 }

--- a/inmates/demos/x86/pci-demo.c
+++ b/inmates/demos/x86/pci-demo.c
@@ -75,6 +75,5 @@ void inmate_main(void)
 	mmio_write16(hdbar + HDA_WAKEEN, 0x0f);
 	mmio_write32(hdbar + HDA_INTCTL, (1 << 31) | (1 << 30));
 
-	while (1)
-		asm volatile("hlt");
+	halt();
 }

--- a/inmates/lib/arm-common/Makefile.lib
+++ b/inmates/lib/arm-common/Makefile.lib
@@ -36,7 +36,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-objs-y := ../string.o ../cmdline.o
+objs-y := ../string.o ../cmdline.o ../setup.o
 objs-y += printk.o gic.o timer.o
 objs-y += uart-jailhouse.o uart-pl011.o uart-8250.o uart-8250-8.o
 objs-y += uart-xuartps.o uart-mvebu.o uart-hscif.o uart-scifa.o uart-imx.o

--- a/inmates/lib/arm-common/include/inmate.h
+++ b/inmates/lib/arm-common/include/inmate.h
@@ -88,6 +88,12 @@ static inline void cpu_relax(void)
 	asm volatile("" : : : "memory");
 }
 
+static inline void __attribute__((noreturn)) halt(void)
+{
+	while (1)
+		asm volatile("wfi" : : : "memory");
+}
+
 typedef void (*irq_handler_t)(unsigned int);
 void gic_setup(irq_handler_t handler);
 void gic_enable_irq(unsigned int irq);

--- a/inmates/lib/arm-common/include/inmate.h
+++ b/inmates/lib/arm-common/include/inmate.h
@@ -39,6 +39,7 @@
 #ifndef _JAILHOUSE_INMATE_H
 #define _JAILHOUSE_INMATE_H
 
+#define COMM_REGION_BASE	0x80000000
 #define PAGE_SIZE	(4 * 1024ULL)
 
 typedef signed char s8;

--- a/inmates/lib/arm/Makefile
+++ b/inmates/lib/arm/Makefile
@@ -41,7 +41,5 @@ include $(INMATES_LIB)/../arm-common/Makefile.lib
 
 always := lib.a inmate.lds
 
-ccflags-y := -ffunction-sections
-
 lib-y := $(common-objs-y)
 lib-y += header.o

--- a/inmates/lib/arm/header.S
+++ b/inmates/lib/arm/header.S
@@ -85,6 +85,6 @@ __reset_entry:
 
 2:	ldr	sp, =stack_top
 
-	b	inmate_main
+	b	c_entry
 
 	.ltorg

--- a/inmates/lib/arm/include/arch/inmate.h
+++ b/inmates/lib/arm/include/arch/inmate.h
@@ -37,3 +37,8 @@
  */
 
 void __attribute__((interrupt("IRQ"), used)) vector_irq(void);
+
+static inline void arch_disable_irqs(void)
+{
+	asm volatile("cpsid if"); /* disable IRQs and FIQs */
+}

--- a/inmates/lib/arm64/header.S
+++ b/inmates/lib/arm64/header.S
@@ -57,7 +57,7 @@ __reset_entry:
 
 	isb
 
-	b	inmate_main
+	b	c_entry
 
 handle_irq:
 	bl	vector_irq

--- a/inmates/lib/arm64/include/arch/inmate.h
+++ b/inmates/lib/arm64/include/arch/inmate.h
@@ -37,3 +37,8 @@
  */
 
 void __attribute__((used)) vector_irq(void);
+
+static inline void arch_disable_irqs(void)
+{
+	asm volatile("msr daifset, #3"); /* disable IRQs and FIQs */
+}

--- a/inmates/lib/inmate_common.h
+++ b/inmates/lib/inmate_common.h
@@ -61,6 +61,12 @@ typedef enum { true = 1, false = 0 } bool;
 
 #define comm_region	((struct jailhouse_comm_region *)COMM_REGION_BASE)
 
+static inline void __attribute__((noreturn)) stop(void)
+{
+	arch_disable_irqs();
+	halt();
+}
+
 void printk(const char *fmt, ...);
 
 void *memset(void *s, int c, unsigned long n);

--- a/inmates/lib/inmate_common.h
+++ b/inmates/lib/inmate_common.h
@@ -71,6 +71,7 @@ void printk(const char *fmt, ...);
 
 void *memset(void *s, int c, unsigned long n);
 void *memcpy(void *d, const void *s, unsigned long n);
+int memcmp(const void *s1, const void *s2, unsigned long n);
 unsigned long strlen(const char *s);
 int strncmp(const char *s1, const char *s2, unsigned long n);
 int strcmp(const char *s1, const char *s2);

--- a/inmates/lib/setup.c
+++ b/inmates/lib/setup.c
@@ -1,0 +1,9 @@
+#include <inmate.h>
+
+void __attribute__((noreturn)) c_entry(void);
+
+void __attribute__((noreturn)) c_entry(void)
+{
+	inmate_main();
+	stop();
+}

--- a/inmates/lib/setup.c
+++ b/inmates/lib/setup.c
@@ -4,6 +4,14 @@ void __attribute__((noreturn)) c_entry(void);
 
 void __attribute__((noreturn)) c_entry(void)
 {
-	inmate_main();
+	/* check if the ABI version of the communication region matches */
+	if (comm_region->revision != COMM_REGION_ABI_REVISION ||
+	    memcmp(comm_region->signature, COMM_REGION_MAGIC,
+		   sizeof(comm_region->signature))) {
+		comm_region->cell_state = JAILHOUSE_CELL_FAILED_COMM_REV;
+	} else {
+		inmate_main();
+	}
+
 	stop();
 }

--- a/inmates/lib/string.c
+++ b/inmates/lib/string.c
@@ -57,6 +57,16 @@ void *memset(void *s, int c, unsigned long n)
 	return s;
 }
 
+int memcmp(const void *s1, const void *s2, unsigned long n)
+{
+	const unsigned char *_s1 = s1, *_s2 = s2;
+
+	while (n-- > 0)
+		if (*_s1++ != *_s2++)
+			return _s1[-1] < _s2[-1] ? -1 : 1;
+	return 0;
+}
+
 unsigned long strlen(const char *s1)
 {
 	unsigned long len = 0;

--- a/inmates/lib/x86/Makefile
+++ b/inmates/lib/x86/Makefile
@@ -41,7 +41,7 @@ include $(INMATES_LIB)/Makefile.lib
 always := lib.a lib32.a
 
 TARGETS := header.o hypercall.o ioapic.o printk.o smp.o
-TARGETS += ../pci.o ../string.o ../cmdline.o
+TARGETS += ../pci.o ../string.o ../cmdline.o ../setup.o
 TARGETS_64_ONLY := int.o mem.o pci.o timing.o
 
 ccflags-y := -ffunction-sections

--- a/inmates/lib/x86/Makefile
+++ b/inmates/lib/x86/Makefile
@@ -44,8 +44,6 @@ TARGETS := header.o hypercall.o ioapic.o printk.o smp.o
 TARGETS += ../pci.o ../string.o ../cmdline.o ../setup.o
 TARGETS_64_ONLY := int.o mem.o pci.o timing.o
 
-ccflags-y := -ffunction-sections
-
 lib-y := $(TARGETS) $(TARGETS_64_ONLY)
 
 lib32-y := $(addprefix $(obj)/,$(TARGETS:.o=-32.o))

--- a/inmates/lib/x86/header-32.S
+++ b/inmates/lib/x86/header-32.S
@@ -109,7 +109,7 @@ start32:
 	mov $bss_dwords,%ecx
 	rep stosl
 
-	mov $inmate_main,%ebx
+	mov $c_entry,%ebx
 
 call_entry:
 	mov $stack_top,%esp

--- a/inmates/lib/x86/header-32.S
+++ b/inmates/lib/x86/header-32.S
@@ -62,6 +62,10 @@ __reset_entry:
 
 
 	.code32
+stop:	cli
+	hlt
+	jmp stop
+
 start32:
 	mov %cr4,%eax
 	or $X86_CR4_PSE,%eax
@@ -113,12 +117,7 @@ start32:
 
 call_entry:
 	mov $stack_top,%esp
-	call *%ebx
-
-stop:	cli
-	hlt
-	jmp stop
-
+	jmp *%ebx
 
 	.pushsection ".data"
 

--- a/inmates/lib/x86/header.S
+++ b/inmates/lib/x86/header.S
@@ -116,7 +116,7 @@ start64:
 	mov $bss_qwords,%rcx
 	rep stosq
 
-	mov $inmate_main,%rbx
+	mov $c_entry,%rbx
 
 call_entry:
 	mov $stack_top,%rsp

--- a/inmates/lib/x86/header.S
+++ b/inmates/lib/x86/header.S
@@ -89,6 +89,10 @@ start32:
 	ljmpl $INMATE_CS64,$start64
 
 	.code64
+stop:	cli
+	hlt
+	jmp stop
+
 start64:
 	xor %rbx,%rbx
 	xchg ap_entry,%rbx
@@ -120,12 +124,7 @@ start64:
 
 call_entry:
 	mov $stack_top,%rsp
-	callq *%rbx
-
-stop:	cli
-	hlt
-	jmp stop
-
+	jmp *%rbx
 
 	.pushsection ".data"
 

--- a/inmates/lib/x86/inmate.h
+++ b/inmates/lib/x86/inmate.h
@@ -101,6 +101,11 @@ typedef unsigned int u32;
 typedef signed long long s64;
 typedef unsigned long long u64;
 
+static inline void arch_disable_irqs(void)
+{
+	asm volatile("cli");
+}
+
 static inline void cpu_relax(void)
 {
 	asm volatile("rep; nop" : : : "memory");

--- a/inmates/lib/x86/inmate.h
+++ b/inmates/lib/x86/inmate.h
@@ -106,6 +106,12 @@ static inline void cpu_relax(void)
 	asm volatile("rep; nop" : : : "memory");
 }
 
+static inline void __attribute__((noreturn)) halt(void)
+{
+	while (1)
+		asm volatile ("hlt" : : : "memory");
+}
+
 static inline void outb(u8 v, u16 port)
 {
 	asm volatile("outb %0,%1" : : "a" (v), "dN" (port));

--- a/inmates/tests/x86/Makefile
+++ b/inmates/tests/x86/Makefile
@@ -12,8 +12,11 @@
 
 include $(INMATES_LIB)/Makefile.lib
 
-INMATES := mmio-access.bin
+INMATES := mmio-access.bin mmio-access-32.bin
 
 mmio-access-y := mmio-access.o
+
+$(eval $(call DECLARE_32_BIT,mmio-access-32))
+mmio-access-32-y := mmio-access-32.o
 
 $(eval $(call DECLARE_TARGETS,$(INMATES)))

--- a/inmates/tests/x86/mmio-access-32.c
+++ b/inmates/tests/x86/mmio-access-32.c
@@ -1,0 +1,134 @@
+/*
+ * Jailhouse, a Linux-based partitioning hypervisor
+ *
+ * Copyright (c) Siemens AG, 2018
+ *
+ * Authors:
+ *  Jan Kiszka <jan.kiszka@siemens.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ */
+
+#include <inmate.h>
+
+#define EXPECT_EQUAL(a, b)	evaluate(a, b, __LINE__)
+
+static bool all_passed = true;
+
+static void evaluate(u32 a, u32 b, int line)
+{
+	bool passed = (a == b);
+
+	printk("Test at line #%d %s\n", line, passed ? "passed" : "FAILED");
+	if (!passed) {
+		printk(" %llx != %llx\n", a, b);
+		all_passed = false;
+	}
+}
+
+void inmate_main(void)
+{
+	volatile u32 *comm_page_reg = (void *)(COMM_REGION_BASE + 0xff8);
+	void *mmio_reg = (void *)(COMM_REGION_BASE + 0x1ff8);
+	u32 pattern, reg32;
+
+	printk("\n");
+
+	/* --- Read Tests --- */
+
+	pattern = 0x11223344;
+	mmio_write32(mmio_reg, pattern);
+	EXPECT_EQUAL(*comm_page_reg, pattern);
+
+	/* MOV_FROM_MEM (8b), 32-bit data, 32-bit address */
+	asm volatile("movl (%%ebx), %%eax"
+		: "=a" (reg32) : "a" (0), "b" (mmio_reg));
+	EXPECT_EQUAL(reg32, pattern);
+
+	/* MOV_FROM_MEM (8a), 8-bit data */
+	asm volatile("movb (%%ebx), %%al"
+		: "=a" (reg32) : "a" (0), "b" (mmio_reg));
+	EXPECT_EQUAL(reg32, (u8)pattern);
+
+	/* MOVZXB (0f b6), 32-bit data, 32-bit address */
+	asm volatile("movzxb (%%ebx), %%eax"
+		: "=a" (reg32) : "a" (0), "b" (mmio_reg));
+	EXPECT_EQUAL(reg32, (u8)pattern);
+
+	/* MOVZXW (0f b7) */
+	asm volatile("movzxw (%%ebx), %%eax"
+		: "=a" (reg32) : "a" (0), "b" (mmio_reg));
+	EXPECT_EQUAL(reg32, (u16)pattern);
+
+	/* MEM_TO_AX (a1), 32-bit data, 32-bit address */
+	asm volatile("mov (0x101ff8), %%eax"
+		: "=a" (reg32) : "a" (0));
+	EXPECT_EQUAL(reg32, pattern);
+
+	printk("MMIO read test %s\n\n", all_passed ? "passed" : "FAILED");
+
+	/* --- Write Tests --- */
+
+	all_passed = true;
+	pattern = 0x8899aabb;
+	mmio_write32(mmio_reg, ~pattern);
+	EXPECT_EQUAL(*comm_page_reg, ~pattern);
+
+	/* MOV_TO_MEM (89), 32-bit data, mod=0, reg=0, rm=4, SIB.base=5 (disp32) */
+	asm volatile("movl %%eax, (0x101ff8)"
+		: : "a" (pattern));
+	EXPECT_EQUAL(*comm_page_reg, pattern);
+
+	/* MOV_TO_MEM (88), 8-bit data */
+	asm volatile("movb %%al, (%%ebx)"
+		: : "a" (0x42), "b" (mmio_reg));
+	EXPECT_EQUAL(*comm_page_reg, (pattern & 0xffffff00) | 0x42);
+
+	/* IMMEDIATE_TO_MEM (c7), 32-bit data, mod=0, reg=0, rm=3 */
+	asm volatile("movl %0, (%%ebx)"
+		: : "i" (0x12345678), "b" (mmio_reg));
+	EXPECT_EQUAL(*comm_page_reg, 0x12345678);
+
+	/* IMMEDIATE_TO_MEM (c7), 32-bit data, mod=1 (disp8), reg=0, rm=3 */
+	asm volatile("movl %0, 0x10(%%ebx)"
+		: : "i" (0x11223344), "b" (mmio_reg - 0x10));
+	EXPECT_EQUAL(*comm_page_reg, 0x11223344);
+
+	/* IMMEDIATE_TO_MEM (c7), 32-bit data, mod=2 (disp32), reg=0, rm=3 */
+	asm volatile("movl %0, 0x10000000(%%ebx)"
+		: : "i" (0xccddeeff), "b" (mmio_reg - 0x10000000));
+	EXPECT_EQUAL(*comm_page_reg, 0xccddeeff);
+
+	/* MOVB_TO_MEM (88), mod=0, reg=0, rm=3 */
+	asm volatile("mov %%al, (%%ebx)"
+		: : "a" (0x99), "b" (mmio_reg));
+	EXPECT_EQUAL(*comm_page_reg, 0xccddee99);
+
+	/* MOV_TO_MEM (89), 32-bit data, mod=1 (disp8), reg=0, rm=3 */
+	asm volatile("movl %%eax, 0x10(%%ebx)"
+		: : "a" (0x12345678), "b" (mmio_reg - 0x10));
+	EXPECT_EQUAL(*comm_page_reg, 0x12345678);
+
+	/* MOV_TO_MEM (89), 32-bit data, mod=2 (disp32), reg=0, rm=3 */
+	asm volatile("movl %%eax, 0x10000000(%%ebx)"
+		: : "a" (0x12345678), "b" (mmio_reg - 0x10000000));
+	EXPECT_EQUAL(*comm_page_reg, 0x12345678);
+
+	/* MOV_TO_MEM (89), 32-bit data, 32-bit address */
+	asm volatile("movl %%eax, 0x10000000(%%ebx)"
+		: : "a" (0x87654321), "b" (mmio_reg - 0x10000000));
+	EXPECT_EQUAL(*comm_page_reg, 0x87654321);
+
+	/* MOV_TO_MEM (89), 32-bit data, mod=0, reg=0, rm=4 (SIB) */
+	asm volatile("movl %%eax, (%%ebx,%%ecx)"
+		: : "a" (0x12345678), "b" (mmio_reg), "c" (0));
+	EXPECT_EQUAL(*comm_page_reg, 0x12345678);
+
+	/* MOV_TO_MEM (89), 32-bit data, mod=2 (disp32), reg=0, rm=4 (SIB) */
+	asm volatile("movl %%eax, 0x10000000(%%ebx,%%ecx)"
+		: : "a" (0x87654321), "b" (mmio_reg - 0x10000000), "c" (0));
+	EXPECT_EQUAL(*comm_page_reg, 0x87654321);
+
+	printk("MMIO write test %s\n", all_passed ? "passed" : "FAILED");
+}

--- a/inmates/tests/x86/mmio-access.c
+++ b/inmates/tests/x86/mmio-access.c
@@ -54,7 +54,12 @@ void inmate_main(void)
 	/* MOV_FROM_MEM (8b), 32-bit data, 32-bit address */
 	asm volatile("movl (%%ebx), %%eax"
 		: "=a" (reg64) : "a" (0), "b" (mmio_reg));
-	EXPECT_EQUAL((u32)reg64, (u32)pattern);
+	EXPECT_EQUAL(reg64, (u32)pattern);
+
+	/* MOV_FROM_MEM (8a), 8-bit data */
+	asm volatile("movb (%%rbx), %%al"
+		: "=a" (reg64) : "a" (0), "b" (mmio_reg));
+	EXPECT_EQUAL(reg64, (u8)pattern);
 
 	/* MOVZXB (0f b6), to 64-bit, mod=0, reg=0, rm=3 */
 	asm volatile("movzxb (%%rbx), %%rax"
@@ -106,6 +111,11 @@ void inmate_main(void)
 	asm volatile("movq %%rax, cmdline+0x101ef8(%%rip)"
 		: : "a" (pattern));
 	EXPECT_EQUAL(*comm_page_reg, pattern);
+
+	/* MOV_TO_MEM (88), 8-bit data */
+	asm volatile("movb %%al, (%%rbx)"
+		: : "a" (0x42), "b" (mmio_reg));
+	EXPECT_EQUAL(*comm_page_reg, (pattern & 0xffffffffffffff00) | 0x42);
 
 	/* IMMEDIATE_TO_MEM (c7), 64-bit data, mod=0, reg=0, rm=3 */
 	asm volatile("movq %0, (%%rbx)"

--- a/scripts/include.mk
+++ b/scripts/include.mk
@@ -25,6 +25,7 @@ sbindir		?= $(exec_prefix)/sbin
 libexecdir	?= $(exec_prefix)/libexec
 datarootdir	?= $(prefix)/share
 datadir		?= $(datarootdir)
+man8dir		?= $(datarootdir)/man/man8
 completionsdir	?= /usr/share/bash-completion/completions
 firmwaredir ?= /lib/firmware
 
@@ -32,6 +33,7 @@ firmwaredir ?= /lib/firmware
 INSTALL_DIRECTORIES := $(sbindir)		\
 		       $(libexecdir)		\
 		       $(datadir)		\
+		       $(man8dir)		\
 		       $(completionsdir)	\
 		       $(firmwaredir)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -37,6 +37,8 @@ HELPERS := \
 	jailhouse-hardware-check
 TEMPLATES := jailhouse-config-collect.tmpl root-cell-config.c.tmpl
 
+MAN8_PAGES := jailhouse.8 jailhouse-cell.8 jailhouse-enable.8
+
 always := $(BINARIES)
 
 HAS_PYTHON_MAKO := \
@@ -93,7 +95,11 @@ install-data: $(TEMPLATES) $(DESTDIR)$(datadir)/jailhouse
 install-completion: jailhouse-completion.bash $(DESTDIR)$(completionsdir)
 	$(INSTALL_DATA) $< $(DESTDIR)$(completionsdir)/jailhouse
 
-install: install-bin install-libexec install-data install-completion
+install-man8: $(MAN8_PAGES) $(DESTDIR)$(man8dir)
+	$(INSTALL_DATA) $^
+
+install: install-bin install-libexec install-data install-completion \
+	 install-man8
 
 $(obj)/no_python_mako:
 	@echo -ne "WARNING: Could not create the helper script to generate" \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -62,6 +62,11 @@ define cmd_gen_collect
 	chmod +x $@
 endef
 
+quiet_cmd_gen_man = GEN     $@
+define cmd_gen_man
+	sed 's/$${VERSION}/$(shell cat $(src)/../VERSION)/g' $< > $@
+endef
+
 targets += jailhouse.o
 
 $(obj)/jailhouse: $(obj)/jailhouse.o
@@ -80,6 +85,12 @@ $(obj)/jailhouse-gcov-extract: $(obj)/jailhouse-gcov-extract.o
 
 $(obj)/jailhouse-config-collect: $(src)/jailhouse-config-create $(src)/jailhouse-config-collect.tmpl
 	$(call if_changed,gen_collect)
+
+targets += $(MAN8_PAGES)
+always +=  $(MAN8_PAGES)
+
+$(obj)/%.8: $(src)/%.8.in
+	$(call if_changed,gen_man)
 
 install-bin: $(BINARIES) $(DESTDIR)$(sbindir)
 	$(INSTALL_PROGRAM) $^

--- a/tools/jailhouse-cell.8
+++ b/tools/jailhouse-cell.8
@@ -1,0 +1,128 @@
+'\" t
+.\"     Title: jailhouse
+.\"    Author: [see the "Authors" section]
+.\"      Date: 14/04/2018
+.\"    Manual: Jailhouse Manual
+.\"    Source: Git 0.8
+.\"  Language: English
+.\"
+.TH "JAILHOUSE-CELL" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+jailhouse-cell \- controlling cells
+.SH "SYNOPSIS"
+.sp
+.nf
+\fIjailhouse\fR cell [collect | create | destroy | linux | load | shutdown | start | stats] [<args>]
+.fi
+.sp
+.SH "DESCRIPTION"
+.sp
+.PP
+\fBjailhouse cell load\fR { ID | [--name] NAME }  { <image_information> } ...
+.RS 4
+.sp
+Where <image_information> is { IMAGE | { -s | --string } "STRING" } [-a | --address ADDRESS]}
+.RE
+.RS 4
+.sp
+Valid forms are:
+.sp
+    # loads inmate\&.bin (offset 0 assumed)
+    jailhouse cell load foocell inmate\&.bin
+.sp
+    # same as above with explicit location
+    jailhouse cell load foocell inmate\&.bin -a 0
+.sp
+    # loads three binary objects (in order)
+    jailhouse cell load foocell \\
+        inmate\&.bin \\
+        sharedobject\&.so -a 0x1000000 \\
+        ramfs\&.bin -a 0x2000000
+.RE
+.RS 4
+.sp
+The first example assumes "-a 0"\&.
+.sp
+The last example, loads in the order specified, three binary objects,
+the first one at offset 0, the second one at 0x1000000\&.
+Should inmate.bin be larger than 0x1000000, the upper part will be overridden
+by sharedobject\&.so\&.
+.sp
+Whatever load order, execution starts in the cell at offset 0 unless otherwise specified in the cell config (cpu_reset_address).\&.
+.sp
+This multi-image loading capability can be used to patch images and
+pass parameters to the image\&. The following explains how parameters are passed
+with the inmate library\&.
+.sp
+The inmate library assumes a command line string to be located at a fixed
+location that is architecture specific:
+.RE
+.RS 4
+- On x86 this is offset 0x100 (see inmates/lib/x86/inmate\&.lds)
+.RE
+.RS 4
+- On arm/arm64, this is offset 0x1000 (see for instance inmates/lib/arm64/inmate\&.lds\&.S)
+.RE
+.RS 4
+.sp
+The command line string capacity is defined during compile time by CMDLINE_BUFFER_SIZE
+in inmates/lib/cmdline\&.c or by defining a non weak instance of CMDLINE_BUFFER()\&.
+Please note that capacity includes trailing \\0.
+.sp
+Here is an example to pass  parameters stored in the file
+commandline.txt to the last example on an x86 system:
+.sp
+    OFFSET=0x100
+    jailhouse cell load foocell \\
+        inmate\&.bin \\
+        commanline\&.txt -a $OFFSET \\
+        sharedobject\&.so -a 0x1000000 \\
+        ramfs\&.bin -a 0x2000000
+.sp
+This command patches inmate.bin at offset 0x100 that corresponds to the "char* cmdline" location as
+controlled by the link script for inmates\&.
+.sp
+Note: on an arm/arm64 we would set OFFSET=0x1000
+.sp
+To be more practical and avoid using a text file, there is an image-as-string
+option:
+.sp
+    OFFSET=0x100
+    jailhouse cell load foocell \\
+        inmate\&.bin \\
+        -s "<command line parameters here>" -a $OFFSET \\
+        sharedobject\&.so -a 0x1000000 \\
+        ramfs\&.bin -a 0x2000000
+.sp
+
+.RE
+
+.SH "SEE ALSO"
+jailhouse(8) jailhouse-enable(8) jailhouse.ko(8)
+.SH "AUTHORS"
+.sp
+Jailhouse was started by Jan Kiszka\&. Contributions have come from the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2>\&.
+.sp
+If you have a clone of jailhouse\&.git itself, the output of \fBgit-shortlog\fR(1) and \fBgit-blame\fR(1) can show you the authors for specific parts of the project\&.
+.SH "REPORTING BUGS"
+.sp
+Report bugs to the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2> where the development and maintenance is primarily done\&. You do not have to be subscribed to the list to send a message there\&.

--- a/tools/jailhouse-cell.8.in
+++ b/tools/jailhouse-cell.8.in
@@ -6,7 +6,7 @@
 .\"    Source: Git 0.8
 .\"  Language: English
 .\"
-.TH "JAILHOUSE-CELL" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.TH "JAILHOUSE-CELL" "8" "14/04/2018" "Jailhouse ${VERSION}" "Jailhouse Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/tools/jailhouse-enable.8
+++ b/tools/jailhouse-enable.8
@@ -1,0 +1,63 @@
+'\" t
+.\"     Title: jailhouse
+.\"    Author: [see the "Authors" section]
+.\"      Date: 14/04/2018
+.\"    Manual: Jailhouse Manual
+.\"    Source: Git 0.8
+.\"  Language: English
+.\"
+.TH "JAILHOUSE-ENABLE" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+jailhouse-enable \- start the lightweight partitioning hypervisor and wraps the running Linux into the root-cell
+.SH "SYNOPSIS"
+.sp
+.nf
+\fIjailhouse enable\fR <sysconfig.cell>
+.fi
+.sp
+.SH "DESCRIPTION"
+Once the jailhouse\&.ko driver is active in the kernel, Jailhouse has to be enabled:
+.sp
+.RS
+\fIjailhouse enable\fR <sysconfig.cell>
+.sp
+<sysconfig.cell> is a Jailhouse binary configuration file that describe all present hardware or the necessary hardware for the root cell to be operational\&. This binary configuration file is obtained by compiling a config file in C language format. On x86, the following command can be used to generate a C language configuration file that represent all known hardware:
+.sp
+.RS
+\fIjailhouse cell create\fR <sysconfig.c>
+.sp
+From this file, the system administrator can remove all hardware that should be dedicated to future cells. Simplest way to compile this file into a <sysconfig.cell> is to copy it in <path to configs/x86/ directory> and launch a build\&.
+.RE
+.sp
+.RE
+.PP
+.RE
+.SH "SEE ALSO"
+jailhouse(8) jailhouse-cell(8) jailhouse.ko(8)
+.SH "AUTHORS"
+.sp
+Jailhouse was started by Jan Kiszka\&. Contributions have come from the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2>\&.
+.sp
+If you have a clone of jailhouse\&.git itself, the output of \fBgit-shortlog\fR(1) and \fBgit-blame\fR(1) can show you the authors for specific parts of the project\&.
+.SH "REPORTING BUGS"
+.sp
+Report bugs to the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2> where the development and maintenance is primarily done\&. You do not have to be subscribed to the list to send a message there\&.

--- a/tools/jailhouse-enable.8.in
+++ b/tools/jailhouse-enable.8.in
@@ -6,7 +6,7 @@
 .\"    Source: Git 0.8
 .\"  Language: English
 .\"
-.TH "JAILHOUSE-ENABLE" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.TH "JAILHOUSE-ENABLE" "8" "14/04/2018" "Jailhouse ${VERSION}" "Jailhouse Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/tools/jailhouse.8
+++ b/tools/jailhouse.8
@@ -1,0 +1,93 @@
+'\" t
+.\"     Title: jailhouse
+.\"    Author: [see the "Authors" section]
+.\"      Date: 14/04/2018
+.\"    Manual: Jailhouse Manual
+.\"    Source: Git 0.8
+.\"  Language: English
+.\"
+.TH "JAILHOUSE" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+jailhouse \- the lightweight partitioning hypervisor
+.SH "SYNOPSIS"
+.sp
+.nf
+\fIjailhouse\fR <command> [<args>]
+.fi
+.sp
+.SH "DESCRIPTION"
+.sp
+Jailhouse is a partitioning Hypervisor based on Linux\&. It is able to run bare-metal applications or (adapted) operating systems besides Linux\&. For this purpose, it configures CPU and device virtualization features of the hardware platform in a way that none of these domains, called "cells" here, can interfere with each other in an unacceptable way\&.
+.sp
+Jailhouse is optimized for simplicity rather than feature richness\&. Unlike full-featured Linux-based hypervisors like KVM or Xen, Jailhouse does not support overcommitment of resources like CPUs, RAM or devices\&. It performs no scheduling and only virtualizes those resources in software, that are essential for a platform and cannot be partitioned in hardware\&.
+.sp
+Once Jailhouse is activated, it runs bare-metal, i\&.e\&. it takes full control over the hardware and needs no external support\&. However, in contrast to other bare-metal hypervisors, it is loaded and configured by a normal Linux system\&. Its management interface is based on Linux infrastructure\&. So you boot Linux first, then you enable Jailhouse and finally you split off parts of the system's resources and assign them to additional cells\&.
+.SH "USAGE FLOW"
+.sp
+Once the jailhouse\&.ko driver is active in the kernel, Jailhouse has to be enabled with the following command:
+.sp
+.RS
+\fIjailhouse enable\fR <sysconfig.cell>
+.sp
+This activates the hypervisor and wraps the executing Linux execution environment into a cell called the "root cell"\&.  It is then  possible to create and tear down cells with jailhouse cell commands\&.  <sysconfig.cell> is a Jailhouse binary configuration file that describe all present hardware but the hardware devices destined to future cells\&.
+.sp
+.RE
+Jailhouse enabled, then it is possible to create and terminate cells with the following set of commands:
+.sp
+.RS 4
+.nf
+\fIjailhouse cell create\fR -name <cellname> <cellconfig.cell>
+\fIjailhouse cell load\fR -name <cellname> <args>
+\fIjailhouse cell start\fR -name <cellname>
+\fIjailhouse cell destroy\fR -name <cellname>
+.fi
+.RE
+.sp
+To terminate jailhouse alltogether, all cells must be destroyed and then hypervisor itself terminated with:
+.sp
+.RS
+\fIjailhouse disable\fR
+.sp
+This unwraps the root cell into a bare metal environment\&. The jalhouse\&.ko driver can be unloaded once Jailhouse has been disabled\&.
+.RE
+.SH "JAILHOUSE COMMANDS"
+.sp
+.PP
+\fBjailhouse-cell\fR(8)
+.PP
+\fBjailhouse-console\fR(8)
+.PP
+\fBjailhouse-disable\fR(8)
+.PP
+\fBjailhouse-enable\fR(8)
+.PP
+\fBjailhouse-hardware\fR(8)
+.SH "SEE ALSO"
+jailhouse-cell(8) jailhouse-enable(8) jailhouse.ko(8)
+.SH "AUTHORS"
+.sp
+Jailhouse was started by Jan Kiszka\&. Contributions have come from the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2>\&.
+.sp
+If you have a clone of jailhouse\&.git itself, the output of \fBgit-shortlog\fR(1) and \fBgit-blame\fR(1) can show you the authors for specific parts of the project\&.
+.SH "REPORTING BUGS"
+.sp
+Report bugs to the Jailhouse mailing list <\m[blue]\fBjailhouse\-dev@googlegroups\&.com\fR\m[]\&\s-2\u\d\s+2> where the development and maintenance is primarily done\&. You do not have to be subscribed to the list to send a message there\&.

--- a/tools/jailhouse.8.in
+++ b/tools/jailhouse.8.in
@@ -6,7 +6,7 @@
 .\"    Source: Git 0.8
 .\"  Language: English
 .\"
-.TH "JAILHOUSE" "8" "14/04/2018" "Jailhouse 0\&.8\&.0" "Jailhouse Manual"
+.TH "JAILHOUSE" "8" "14/04/2018" "Jailhouse ${VERSION}" "Jailhouse Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/tools/jailhouse.c
+++ b/tools/jailhouse.c
@@ -359,13 +359,13 @@ static int cell_list(int argc, char *argv[])
 	}
 
 	if (num_entries > 0)
-		printf("%-8s%-24s%-16s%-24s%-24s\n",
+		printf("%-8s%-24s%-18s%-24s%-24s\n",
 		       "ID", "Name", "State", "Assigned CPUs", "Failed CPUs");
 	for (i = 0; i < num_entries; i++) {
 		id = (unsigned int)strtoul(namelist[i]->d_name, NULL, 10);
 
 		cinfo = get_cell_info(id);
-		printf("%-8d%-24s%-16s%-24s%-24s\n", cinfo->id.id, cinfo->id.name,
+		printf("%-8d%-24s%-18s%-24s%-24s\n", cinfo->id.id, cinfo->id.name,
 		       cinfo->state, cinfo->cpus_assigned_list, cinfo->cpus_failed_list);
 		cell_info_free(cinfo);
 		free(namelist[i]);


### PR DESCRIPTION
Setup on ZCU102 ZynqMP Ultrascale+
============================================
The ZCU102 target is a Xilinx target based on ZynqMP Ultrascale+. The SoC is a quad-core Cortex-A53 and a dual-core R5 real-time processor. Further information can be found on https://www.xilinx.com/products/boards-and-kits/ek-u1-zcu102-g.html

The Linux Image which runs Jailhouse has been built with Petalinux 2017.4. Petalinux uses linux-xlnx repository, and in this case it uses the xilinx-v2017.4 one, which is based on 4.9 kernel.


Image build
-------------------------------------------
In order to build the Linux image with Petalinux it is necessary to set all the environmental variables. 

    $ source /opt/pkg/settings.sh

Once petalinux environments are set, the Petalinux project is created with the name lnx_jailhouse. The bsp has to be downloaded.

    $ petalinux-create -t project --template zynqMP -s ../xilinx-zcu102-v2017.4-final.bsp -n lnx_jailhouse

The Linux project is configured by:

    $ petalinux-config 

A menuconfig window is opened and just enable `Root filesystem type (SD card)`:

    Image Packaging Configuration--->Root filesystem type-->SD card

Save project and exit. It will take some to time to configure the project. Once it has finished configuring, the Linux kenel needs to be configured enabling `CONFIG_OF_OVERLAY` and `CONFIG_KALLSYMS_ALL`

    $ petalinux-config -c kernel

Once modified, save the changes and build the project.

    $ petalinux-build
    $ petalinux-package --boot --u-boot


Jailhouse build
-------------------------------------------
In the Jailhouse source directory, create a file include/jailhouse/config.h with the following lines:

#define CONFIG_TRACE_ERROR             1
#define CONFIG_ARM_GIC_V2              1
#define CONFIG_MACH_ZYNQMP_ZCU102      1

After that, it is possible to build the project. It is necessary to set the variables `ARCH=` with arm64, `KDIR=` with the kernel directory inside the Petalinux project, `CROSS_COMPILE=` with the compiler and `DESTDIR=` with the rootfs directory.

    $ make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KDIR=../lnx_jailhouse/build/tmp/work/plnx_aarch64-xilinx-linux/linux-xlnx/4.9-xilinx-v2017.4+gitAUTOINC+b450e900fd-r0/linux-plnx_aarch64-standard-build/ DESTDIR=/media/user/rootfs install

This command will add the jailhouse module and its binary. 


U-Boot
------------------------------------------
Jailhouse needs the Linux kernel boot parameters `mem=`  to be set in order to reserve memory for other cells.
In this case we chose `mem=1536M`. This can be done through U-Boot:

    ZynqMP> setenv bootargs "earlycon clk_ignore_unused earlyprintk mem=1536M root=/dev/mmcblk0p2 rw rootwait"
    ZynqMP> setenv uenvcmd "fatload mmc 0 0x3000000 Image && fatload mmc 0 0x2A00000 system.dtb && booti 0x3000000 - 0x2A00000"
    ZynqMP> setenv bootcmd "run uenvcmd"
    ZynqMP> saveenv
    ZynqMP> boot


Testing Jailhouse GIC Demo
-------------------------------------------
Copy the `configs/arm64/zynqmp-zcu102*.cell` to the rootfs. To test Jailhouse it is also interesting to copy `inmates/demos/arm64/gic-demo.bin`. This demo creates a periodic timer interrupt and calculates its jitter. Once Linux is running:

    # modprobe jailhouse
    [   24.309597] jailhouse: loading out-of-tree module taints kernel.
    
    # jailhouse enable zynqmp-zcu102.cell
    Initializing Jailhouse hypervisor v0.8 on CPU 2
    Code location: 0x0000ffffc0200060
    Page pool usage after early setup: mem 33/993, remap 64/131072
    Initializing processors:
     CPU 2... OK
     CPU 0... OK
     CPU 3... OK
     CPU 1... OK
    Initializing unit: irqchip
    Initializing unit: PCI
    Adding virtual PCI device 00:00.0 to cell "ZynqMP-ZCU102"
    Adding virtual PCI device 00:01.0 to cell "ZynqMP-ZCU102"
    Page pool usage after late setup: mem 42/993, remap 69/131072
    Activating hypervisor
    [   39.844953] The Jailhouse is opening.

    # jailhouse cell create zynqmp-zcu102-gic-demo.cell
    [   55.351670] CPU3: shutdown
    [   55.354303] psci: CPU3 killed.
    Created cell "gic-demo"
    Page pool usage after cell creation: mem 56/993, remap 69/131072
    [   55.388029] Created Jailhouse cell "gic-demo"
    
    # jailhouse cell load 1 gic-demo.bin
    Cell "gic-demo" can be loaded
    # jailhouse cell start 1

Second UART starts showing jitter data:

    Timer fired, jitter:   2212 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2171 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2454 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2444 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2181 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2181 ns, min:   2101 ns, max:   2585 ns
    Timer fired, jitter:   2212 ns, min:   2101 ns, max:   2585 ns

If second UART does not show anything, the error can be in the DTB. The last Xilinx DTBs are not Jailhouse compatible. Therefore, it is recommendable to use a 2016 repository DTB, such as, https://github.com/Xilinx/linux-xlnx/blob/xilinx-v2016.4/arch/arm64/boot/dts/xilinx/zynqmp-zcu102.dts

Testing Jailhouse Linux
-------------------------------------------
It is possible to load a Linux image in a guest cell. In order to do that, it is essential to do a new Linux image but with `Image Packaging Configuration--->Root filesystem type-->INITRAMFS`. 

The files `image/linux/Image` and `image/linux/rootfs.cpio` have to be copied from the Petalinux project to the rootfs. Besides, `configs/arm64/dts/inmate-zynqmp-zcu102.dtb` file has to be copied from Jailhouse project. 

To load Linux in the guest cell:

    # modprobe jailhouse
    [   24.309597] jailhouse: loading out-of-tree module taints kernel.
    
    # jailhouse enable zynqmp-zcu102.cell
    Initializing Jailhouse hypervisor v0.8 on CPU 2
    Code location: 0x0000ffffc0200060
    Page pool usage after early setup: mem 33/993, remap 64/131072
    Initializing processors:
     CPU 2... OK
     CPU 0... OK
     CPU 3... OK
     CPU 1... OK
    Initializing unit: irqchip
    Initializing unit: PCI
    Adding virtual PCI device 00:00.0 to cell "ZynqMP-ZCU102"
    Adding virtual PCI device 00:01.0 to cell "ZynqMP-ZCU102"
    Page pool usage after late setup: mem 42/993, remap 69/131072
    Activating hypervisor
    [   39.844953] The Jailhouse is opening.
    
    # jailhouse cell linux zynqmp-zcu102-linux-demo.cell Image -d inmate-zynqmp-zcu102.dtb -i rootfs.cpio -c "console=ttyPS0,115200"
    [   81.967652] CPU2: shutdown
    [   81.970285] psci: CPU2 killed.
    [   82.015619] CPU3: shutdown
    [   82.018242] psci: CPU3 killed.
    Adding virtual PCI device 00:00.0 to cell "ZynqMP-linux-demo"
    Shared memory connection established: "ZynqMP-linux-demo" <--> "ZynqMP-ZCU102"
    Adding virtual PCI device 00:02.0 to cell "ZynqMP-linux-demo"
    Created cell "ZynqMP-linux-demo"
    Page pool usage after cell creation: mem 61/993, remap 69/131072
    [   82.062667] Created Jailhouse cell "ZynqMP-linux-demo"
    Cell "ZynqMP-linux-demo" can be loaded
    Started cell "ZynqMP-linux-demo"
    
Guest Linux booting will appear in the second UART. It possible to see the state of each cell:

    root@xilinx-zcu102-2017_4:/# jailhouse cell list
    ID      Name                    State             Assigned CPUs           Failed CPUs
    0       ZynqMP-ZCU102           running           0-1
    1       ZynqMP-linux-demo       running           2-3

Debug in ZCU102
-------------------------------------------
It is possible to Debug Jailhouse in the ZCU102. Add `JAILHOUSE_CELL_DEBUG_CONSOLE` to the cell config (see e.g.
configs/arm64/qemu-arm64-linux-demo.c). After that, just add the following info in the cell load:

    # jailhouse cell load 1 gic-demo.bin -s "con-type=JAILHOUSE" -a 0x1000
    
The output can be seen in:

    # jailhouse console -f









