### PR TITLE
hardware check: Catch errors opening /dev/mem during MMIO check

### DIFF
--- a/tools/jailhouse-hardware-check
+++ b/tools/jailhouse-hardware-check
@@ -102,8 +102,13 @@ class MSR:
 
 class MMIO:
     def __init__(self, base, size):
-        f = os.open('/dev/mem', os.O_RDONLY | os.O_SYNC)
         self.mmap = None
+        try:
+            f = os.open('/dev/mem', os.O_RDONLY | os.O_SYNC)
+        except OSError as e:
+            print(' ERROR: Failed to open /dev/mem: %s' % e)
+            return
+
         try:
             self.mmap = mmap.mmap(f, size, mmap.MAP_SHARED, mmap.PROT_READ,
                                   offset=base)


### PR DESCRIPTION
Catch error, print, and continue, instead of exiting entire test.

Kernel config `CONFIG_STRICT_DEVMEM` is enabled by default on newer
kernels, causing these failures.

Here is what it looks like before applying the patch on my Kubuntu 18.04 system:

```
hintron@inspiron:~/code/jailhouse$ sudo ./tools/jailhouse hardware check
Feature                         Availability
------------------------------  ------------------
Number of CPUs > 1              ok
Long mode                       ok
x2APIC                          ok

VT-x (VMX)                      ok
  VMX outside SMX               ok
  VMX inside SMX                missing (optional)
  IA32_TRUE_*_CLTS              ok
  NMI exiting                   ok
  Preemption timer              ok
  I/O bitmap                    ok
  MSR bitmap                    ok
  Secondary controls            ok
  Optional CR3 interception     ok
  Virtualize APIC access        ok
  RDTSCP                        ok
  Unrestricted guest            ok
  EPT                           ok
    4-level page walk           ok
    EPTP write-back             ok
    2M pages                    ok
    1G pages                    ok
    INVEPT                      ok
      Single or all-context     ok
  VM-exit save IA32_PAT         ok
  VM-exit load IA32_PAT         ok
  VM-exit save IA32_EFER        ok
  VM-exit load IA32_EFER        ok
  VM-entry load IA32_PAT        ok
  VM-entry load IA32_EFER       ok
  Activity state HLT            ok

VT-d (IOMMU #0)                 ok
Traceback (most recent call last):
  File "./tools/jailhouse-hardware-check", line 255, in <module>
    mmio = MMIO(iommu[n].base_addr, iommu[n].mmio_size)
  File "./tools/jailhouse-hardware-check", line 105, in __init__
    f = os.open('/dev/mem', os.O_RDONLY | os.O_SYNC)
OSError: [Errno 1] Operation not permitted: '/dev/mem'
```
And here's what it looks like after the patch:
```
hintron@inspiron:~/code/jailhouse$ sudo ./tools/jailhouse hardware check 
Feature                         Availability
------------------------------  ------------------
Number of CPUs > 1              ok
Long mode                       ok
x2APIC                          ok

VT-x (VMX)                      ok
  VMX outside SMX               ok
  VMX inside SMX                missing (optional)
  IA32_TRUE_*_CLTS              ok
  NMI exiting                   ok
  Preemption timer              ok
  I/O bitmap                    ok
  MSR bitmap                    ok
  Secondary controls            ok
  Optional CR3 interception     ok
  Virtualize APIC access        ok
  RDTSCP                        ok
  Unrestricted guest            ok
  EPT                           ok
    4-level page walk           ok
    EPTP write-back             ok
    2M pages                    ok
    1G pages                    ok
    INVEPT                      ok
      Single or all-context     ok
  VM-exit save IA32_PAT         ok
  VM-exit load IA32_PAT         ok
  VM-exit save IA32_EFER        ok
  VM-exit load IA32_EFER        ok
  VM-entry load IA32_PAT        ok
  VM-entry load IA32_EFER       ok
  Activity state HLT            ok

VT-d (IOMMU #0)                 ok
 ERROR: Failed to open /dev/mem: [Errno 1] Operation not permitted: '/dev/mem'
 Skipping MMIO tests, your kernel might have CONFIG_STRICT_DEVMEM enabled.
 Disable for thorough testing.


VT-d (IOMMU #1)                 ok
 ERROR: Failed to open /dev/mem: [Errno 1] Operation not permitted: '/dev/mem'
 Skipping MMIO tests, your kernel might have CONFIG_STRICT_DEVMEM enabled.
 Disable for thorough testing.


Check passed!
BUT: Some essential checks had to be skipped!
```