### PR TITLE
Update processor.h for compatibility with Intel processors supporting…

### DIFF
--- a/hypervisor/arch/x86/include/asm/processor.h
+++ b/hypervisor/arch/x86/include/asm/processor.h
@@ -66,7 +66,7 @@
 #define X86_CR4_VMXE					(1UL << 13)
 #define X86_CR4_OSXSAVE					(1UL << 18)
 #define X86_CR4_RESERVED				\
-	(BIT_MASK(31, 22) | (1UL << 19) | (1UL << 15) | BIT_MASK(12, 11))
+	(BIT_MASK(31, 23) | (1UL << 19) | (1UL << 15) | BIT_MASK(12, 11))
 
 #define X86_XCR0_FP					0x00000001
 


### PR DESCRIPTION
… extensions for page protection keys

CR4 bit 22 is not reserved. On newer processors it is used to enable the Intel Protection Key Enable feature. Without this change skylake-server (and newer) CPUs will fail in vcpu_init.