### PR TITLE
tools/Makefile: fix install of jailhouse-config-collect

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -35,8 +35,24 @@ KBUILD_CFLAGS += $(call cc-option, -no-pie)
 BINARIES := jailhouse
 always := $(BINARIES)
 
+HAS_PYTHON_MAKO := \
+	$(shell $(PYTHON) -c "from mako.template import Template" 2>/dev/null \
+	&& echo yes)
+
+ifeq ($(strip $(HAS_PYTHON_MAKO)), yes)
+always += jailhouse-config-collect
+HELPERS := jailhouse-config-collect
+
+else  # !HAS_PYTHON_MAKO
+
+$(info WARNING: Could not create the helper script to generate \
+	   configurations on remote machines \
+	   ("jailhouse-conf-collect"). You need Python and the \
+	   Mako library for it.)
+endif # !HAS_PYTHON_MAKO
+
 ifeq ($(strip $(PYTHON_PIP_USABLE)), yes)
-HELPERS := \
+HELPERS += \
 	jailhouse-cell-linux \
 	jailhouse-cell-stats \
 	jailhouse-config-create \
@@ -61,22 +77,6 @@ install::
 	$(info WARNING: Could not install Python-based helpers. You need \
 		   Python and pip in order to install them.)
 endif # !PYTHON_PIP_USABLE
-
-HAS_PYTHON_MAKO := \
-	$(shell $(PYTHON) -c "from mako.template import Template" 2>/dev/null \
-	&& echo yes)
-
-ifeq ($(strip $(HAS_PYTHON_MAKO)), yes)
-always += jailhouse-config-collect
-HELPERS += jailhouse-config-collect
-
-else  # !HAS_PYTHON_MAKO
-
-$(info WARNING: Could not create the helper script to generate \
-	   configurations on remote machines \
-	   ("jailhouse-conf-collect"). You need Python and the \
-	   Mako library for it.)
-endif # !HAS_PYTHON_MAKO
 
 MAN8_PAGES := jailhouse.8 jailhouse-cell.8 jailhouse-enable.8
 


### PR DESCRIPTION
Since commit 37bc6c12a1b365250c0dcdd82ae1ac5a869898e1,
jailhouse-config-collect is not installed anymore on target as HELPERS
is updated after install-libexec target so fix this mistake

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>